### PR TITLE
feat: add photocalia.com to allowed origins

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -16,6 +16,8 @@ setGlobalOptions({ maxInstances: 10 });
 const allowedOrigins = [
   'https://3dime.com',
   'https://www.3dime.com',
+  'https://photocalia.com',
+  'https://www.photocalia.com',
   'http://localhost:4200',
   'http://localhost:5000'
 ];

--- a/functions/src/proxies/converter.ts
+++ b/functions/src/proxies/converter.ts
@@ -8,6 +8,8 @@ import { getQuotaService } from "../services/quota";
 const allowedOrigins = [
   'https://3dime.com',
   'https://www.3dime.com',
+  'https://photocalia.com',
+  'https://www.photocalia.com',
   'http://localhost:4200',
   'http://localhost:5000'
 ];

--- a/functions/src/proxies/githubCommits.ts
+++ b/functions/src/proxies/githubCommits.ts
@@ -10,6 +10,8 @@ initializeFirebaseAdmin();
 const allowedOrigins = [
   'https://3dime.com',
   'https://www.3dime.com',
+  'https://photocalia.com',
+  'https://www.photocalia.com',
   'http://localhost:4200',
   'http://localhost:5000'
 ];

--- a/functions/src/proxies/githubSocial.ts
+++ b/functions/src/proxies/githubSocial.ts
@@ -10,6 +10,8 @@ initializeFirebaseAdmin();
 const allowedOrigins = [
   'https://3dime.com',
   'https://www.3dime.com',
+  'https://photocalia.com',
+  'https://www.photocalia.com',
   'http://localhost:4200',
   'http://localhost:5000'
 ];

--- a/functions/src/proxies/notion.ts
+++ b/functions/src/proxies/notion.ts
@@ -15,6 +15,8 @@ const FORCE_COOLDOWN = 5 * 60 * 1000; // 5 minutes
 const allowedOrigins = [
   "https://3dime.com",
   "https://www.3dime.com",
+  "https://photocalia.com",
+  "https://www.photocalia.com",
   "http://localhost:4200",
   "http://localhost:5000",
 ];

--- a/functions/src/proxies/quotaStatus.ts
+++ b/functions/src/proxies/quotaStatus.ts
@@ -6,6 +6,8 @@ import { getQuotaService } from "../services/quota";
 const allowedOrigins = [
   'https://3dime.com',
   'https://www.3dime.com',
+  'https://photocalia.com',
+  'https://www.photocalia.com',
   'http://localhost:4200',
   'http://localhost:5000'
 ];

--- a/functions/src/proxies/statistics.ts
+++ b/functions/src/proxies/statistics.ts
@@ -12,6 +12,8 @@ initializeFirebaseAdmin();
 const allowedOrigins = [
   'https://3dime.com',
   'https://www.3dime.com',
+  'https://photocalia.com',
+  'https://www.photocalia.com',
   'http://localhost:4200',
   'http://localhost:5000'
 ];


### PR DESCRIPTION
This pull request updates CORS (Cross-Origin Resource Sharing) settings across several proxy and index files to allow requests from the `photocalia.com` and `www.photocalia.com` domains, in addition to the existing allowed origins. This change enables these new domains to access backend functions and APIs.

CORS configuration updates:

* Added `https://photocalia.com` and `https://www.photocalia.com` to the `allowedOrigins` arrays in the following files:
  - `functions/src/index.ts`
  - `functions/src/proxies/converter.ts`
  - `functions/src/proxies/githubCommits.ts`
  - `functions/src/proxies/githubSocial.ts`
  - `functions/src/proxies/notion.ts`
  - `functions/src/proxies/quotaStatus.ts`
  - `functions/src/proxies/statistics.ts`