### PR TITLE
feat: update branding from 3dime to Photocalia in SEO improvements and route titles

### DIFF
--- a/docs/SEO_IMPROVEMENTS.md
+++ b/docs/SEO_IMPROVEMENTS.md
@@ -16,7 +16,7 @@ This document outlines the comprehensive SEO improvements implemented for the 3d
 
 **After:**
 ```html
-<title>Free AI Calendar Converter - Convert Images & PDFs to ICS Calendar Files | 3dime</title>
+<title>Free AI Calendar Converter - Convert Images & PDFs to ICS Calendar Files | Photocalia</title>
 ```
 
 **Benefits:**

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,12 +6,12 @@ export const routes: Routes = [
   {
     path: '',
     component: Home,
-    title: 'Calendar Converter | 3dime',
+    title: 'Calendar Converter | Photocalia',
   },
   {
     path: 'me',
     component: About,
-    title: 'About Me | 3dime',
+    title: 'About Me | Photocalia',
   },
   {
     path: '**',


### PR DESCRIPTION
This pull request updates the branding throughout the application from "3dime" to "Photocalia". The most important changes include updating page titles in both documentation and routing configuration.

Branding updates:

* Changed the main page and "About Me" route titles in `src/app/app.routes.ts` to use "Photocalia" instead of "3dime".
* Updated the HTML `<title>` example in `docs/SEO_IMPROVEMENTS.md` to reference "Photocalia".