### PR TITLE
feat: implement SEO service and update routes with SEO metadata

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,11 +7,32 @@ export const routes: Routes = [
     path: '',
     component: Home,
     title: 'Calendar Converter | Photocalia',
+    data: {
+      seo: {
+        title: 'Free AI Calendar Converter - Convert Images & PDFs to ICS Calendar Files | Photocalia',
+        description: 'Free AI-powered calendar converter: Instantly transform screenshots, images, and PDF documents into ICS calendar files. Convert appointment reminders, event flyers, schedules, and meeting invitations to Google Calendar, Outlook, Apple Calendar.',
+        keywords: 'calendar converter, image to calendar, PDF to calendar, ICS generator, AI calendar extraction, screenshot to calendar, appointment converter, event converter, calendar OCR',
+        ogImage: 'https://photocalia.com/assets/images/converter.png',
+        ogUrl: 'https://photocalia.com/',
+        type: 'website'
+      }
+    }
   },
   {
     path: 'me',
     component: About,
     title: 'About Me | Photocalia',
+    data: {
+      seo: {
+        title: 'About Me - Idriss Mohamady | Photocalia',
+        description: 'Tech enthusiast and developer specializing in Java and modern web technologies. French of Malagasy origin, building elegant solutions that keep things simple.',
+        keywords: 'Idriss Mohamady, Back End developer, Java, Quarkus, Spring Boot, web developer, software engineer, 3dime',
+        ogImage: 'https://photocalia.com/assets/logo.png',
+        ogUrl: 'https://photocalia.com/me',
+        type: 'profile',
+        author: 'Idriss Mohamady'
+      }
+    }
   },
   {
     path: '**',

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -9,6 +9,7 @@ import { Footer } from './components/footer/footer';
 import { Stats } from './components/stats/stats';
 import { PWA_CONFIG } from './constants/pwa.constants';
 import { AuthService } from './services/auth.service';
+import { SeoService } from './services/seo.service';
 
 @Component({
   selector: 'app-root',
@@ -22,6 +23,7 @@ export class App implements OnInit {
   private readonly swUpdate = inject(SwUpdate);
   private readonly router = inject(Router);
   private readonly authService = inject(AuthService);
+  private readonly seoService = inject(SeoService);
 
   protected readonly title = signal('3dime-angular');
   protected readonly currentRoute = signal<string>('');

--- a/src/app/services/seo.service.ts
+++ b/src/app/services/seo.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, inject } from '@angular/core';
+import { Title, Meta } from '@angular/platform-browser';
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
+import { filter, map, mergeMap } from 'rxjs/operators';
+import { DOCUMENT } from '@angular/common';
+
+export interface SeoData {
+    title: string;
+    description: string;
+    keywords?: string;
+    ogImage?: string;
+    ogUrl?: string;
+    author?: string;
+    type?: string;
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class SeoService {
+    private titleService = inject(Title);
+    private metaService = inject(Meta);
+    private router = inject(Router);
+    private activatedRoute = inject(ActivatedRoute);
+    private dom = inject(DOCUMENT);
+
+    constructor() {
+        this.setupRouting();
+    }
+
+    private setupRouting() {
+        this.router.events.pipe(
+            filter(event => event instanceof NavigationEnd),
+            map(() => this.activatedRoute),
+            map(route => {
+                while (route.firstChild) {
+                    route = route.firstChild;
+                }
+                return route;
+            }),
+            filter(route => route.outlet === 'primary'),
+            mergeMap(route => route.data)
+        ).subscribe((data: any) => {
+            if (data.seo) {
+                this.updateSeoTags(data.seo);
+            }
+        });
+    }
+
+    updateSeoTags(seo: SeoData) {
+        // Set Title
+        this.titleService.setTitle(seo.title);
+
+        // Set Meta Tags
+        this.metaService.updateTag({ name: 'description', content: seo.description });
+
+        if (seo.keywords) {
+            this.metaService.updateTag({ name: 'keywords', content: seo.keywords });
+        }
+
+        if (seo.author) {
+            this.metaService.updateTag({ name: 'author', content: seo.author });
+        }
+
+        // Open Graph Tags
+        this.metaService.updateTag({ property: 'og:title', content: seo.title });
+        this.metaService.updateTag({ property: 'og:description', content: seo.description });
+        this.metaService.updateTag({ property: 'og:type', content: seo.type || 'website' });
+        this.metaService.updateTag({ property: 'og:url', content: seo.ogUrl || this.dom.location.href });
+
+        if (seo.ogImage) {
+            this.metaService.updateTag({ property: 'og:image', content: seo.ogImage });
+        }
+
+        // Twitter Card Tags
+        this.metaService.updateTag({ name: 'twitter:card', content: 'summary_large_image' });
+        this.metaService.updateTag({ name: 'twitter:title', content: seo.title });
+        this.metaService.updateTag({ name: 'twitter:description', content: seo.description });
+
+        if (seo.ogImage) {
+            this.metaService.updateTag({ name: 'twitter:image', content: seo.ogImage });
+        }
+
+        // Update Canonical URL
+        this.updateCanonicalUrl(seo.ogUrl || this.dom.location.href);
+    }
+
+    private updateCanonicalUrl(url: string) {
+        let link: HTMLLinkElement | null = this.dom.querySelector('link[rel="canonical"]');
+        if (!link) {
+            link = this.dom.createElement('link');
+            link.setAttribute('rel', 'canonical');
+            this.dom.head.appendChild(link);
+        }
+        link.setAttribute('href', url);
+    }
+}


### PR DESCRIPTION
This pull request introduces dynamic SEO metadata management to the Angular application. The main changes include adding a new `SeoService` that automatically updates meta tags and Open Graph/Twitter information based on route data, and updating route definitions to provide SEO metadata for key pages.

**SEO Metadata Management Improvements:**

* Added a new `SeoService` (`src/app/services/seo.service.ts`) that listens to route changes and updates page title, meta tags, Open Graph, Twitter card tags, and the canonical URL based on the `seo` data defined in each route.
* Updated the main application component (`src/app/app.ts`) to inject and initialize the new `SeoService`, ensuring that SEO updates are triggered on navigation. [[1]](diffhunk://#diff-18f0b78b713daf3f4fc2d305926785508575bdc7f304363a64a3b3a2985b58beR12) [[2]](diffhunk://#diff-18f0b78b713daf3f4fc2d305926785508575bdc7f304363a64a3b3a2985b58beR26)

**Route Configuration Enhancements:**

* Enhanced route definitions in `src/app/app.routes.ts` to include detailed `seo` metadata (title, description, keywords, Open Graph, etc.) for the home and about pages, enabling rich previews and better search engine optimization.