### PR TITLE
feat: update benefit description for clarity and specificity

### DIFF
--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -159,8 +159,8 @@
         <div class="benefit-item">
           <div class="benefit-check">✓</div>
           <div class="benefit-content">
-            <h3 class="benefit-title">Free & Unlimited</h3>
-            <p class="benefit-description">No hidden costs or limits</p>
+            <h3 class="benefit-title">Free (For personal use)</h3>
+            <p class="benefit-description">No hidden costs</p>
           </div>
         </div>
 

--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -159,7 +159,7 @@
         <div class="benefit-item">
           <div class="benefit-check">✓</div>
           <div class="benefit-content">
-            <h3 class="benefit-title">Free (For personal use)</h3>
+            <h3 class="benefit-title">Free (for personal use)</h3>
             <p class="benefit-description">No hidden costs</p>
           </div>
         </div>


### PR DESCRIPTION
This pull request makes a minor update to the home page content. The change clarifies the benefit description regarding the free usage of the product.

* Updated the benefit title and description in `src/app/pages/home/home.html` to specify "Free (For personal use)" and removed the mention of "unlimited" and "no limits".