### PR TITLE
feat: update footer links and branding to Photocalia

### DIFF
--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -1,6 +1,6 @@
 <footer class="global-footer" role="contentinfo">
   <div class="footer-container">
-    <span class="footer-text">© {{ currentYear }} Photocalia</span>
+    <span class="footer-text">© {{ currentYear }} PhotoCalia</span>
     <a
       [href]="releaseUrl"
       target="_blank"

--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -1,6 +1,6 @@
 <footer class="global-footer" role="contentinfo">
   <div class="footer-container">
-    <span class="footer-text">© {{ currentYear }} 3dime</span>
+    <span class="footer-text">© {{ currentYear }} Photocalia</span>
     <a
       [href]="releaseUrl"
       target="_blank"

--- a/src/app/components/footer/footer.ts
+++ b/src/app/components/footer/footer.ts
@@ -40,7 +40,7 @@ export class Footer implements OnInit {
   //  { label: 'Security', url: `${this.githubRepo}/blob/main/SECURITY.md` },
   //  { label: 'Community', url: `${this.githubRepo}/blob/main/CONTRIBUTING.md` },
   //  { label: 'Discussions', url: `${this.githubRepo}/discussions` },
-  //  { label: 'About Me', url: '/me', isInternal: true },
+    { label: 'About Me', url: '/me', isInternal: true },
   ];
 
   ngOnInit(): void {

--- a/src/app/components/footer/footer.ts
+++ b/src/app/components/footer/footer.ts
@@ -33,14 +33,14 @@ export class Footer implements OnInit {
   authorProfile = 'https://github.com/m-idriss';
 
   footerLinks: FooterLink[] = [
-    { label: 'Repository', url: this.githubRepo },
-    { label: 'Issues', url: `${this.githubRepo}/issues` },
-    { label: 'Docs', url: `${this.githubRepo}/blob/main/README.md` },
+  //  { label: 'Repository', url: this.githubRepo },
+  //  { label: 'Issues', url: `${this.githubRepo}/issues` },
+  //  { label: 'Docs', url: `${this.githubRepo}/blob/main/README.md` },
     { label: 'License', url: `${this.githubRepo}/blob/main/LICENSE` },
-    { label: 'Security', url: `${this.githubRepo}/blob/main/SECURITY.md` },
-    { label: 'Community', url: `${this.githubRepo}/blob/main/CONTRIBUTING.md` },
-    { label: 'Discussions', url: `${this.githubRepo}/discussions` },
-    { label: 'About Me', url: '/me', isInternal: true },
+  //  { label: 'Security', url: `${this.githubRepo}/blob/main/SECURITY.md` },
+  //  { label: 'Community', url: `${this.githubRepo}/blob/main/CONTRIBUTING.md` },
+  //  { label: 'Discussions', url: `${this.githubRepo}/discussions` },
+  //  { label: 'About Me', url: '/me', isInternal: true },
   ];
 
   ngOnInit(): void {


### PR DESCRIPTION

This pull request updates the footer component to reflect a change in branding and temporarily removes several footer links. The most important changes are grouped below:

Branding update:

* Changed the footer text in `footer.html` from "3dime" to "Photocalia" to reflect the new project name.

Footer links adjustment:

* Commented out several links in the `footerLinks` array in `footer.ts`, including "Repository", "Issues", "Docs", "Security", "Community", "Discussions", and "About Me", leaving only the "License" link active.