### PR TITLE
seo: add WebApplication JSON-LD schema and update sitemap lastmod dates

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,7 +8,7 @@
   <!-- Homepage / Calendar Converter -->
   <url>
     <loc>https://photocalia.com/</loc>
-    <lastmod>2026-03-02</lastmod>
+    <lastmod>2026-03-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -21,7 +21,7 @@
   <!-- How It Works Page -->
   <url>
     <loc>https://photocalia.com/how-it-works</loc>
-    <lastmod>2026-03-02</lastmod>
+    <lastmod>2026-03-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -34,7 +34,7 @@
   <!-- Privacy Policy Page -->
   <url>
     <loc>https://photocalia.com/privacy</loc>
-    <lastmod>2026-03-02</lastmod>
+    <lastmod>2026-03-10</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -42,7 +42,7 @@
   <!-- Terms of Use Page -->
   <url>
     <loc>https://photocalia.com/terms</loc>
-    <lastmod>2026-03-02</lastmod>
+    <lastmod>2026-03-10</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -50,7 +50,7 @@
   <!-- Legal Mentions Page -->
   <url>
     <loc>https://photocalia.com/legal-mentions</loc>
-    <lastmod>2026-03-02</lastmod>
+    <lastmod>2026-03-10</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/src/index.html
+++ b/src/index.html
@@ -270,6 +270,24 @@
       }
     </script>
 
+    <!-- WebApplication Schema -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "Photocalia",
+        "url": "https://photocalia.com",
+        "description": "Convert photos, screenshots and flyers to calendar events with AI.",
+        "applicationCategory": "ProductivityApplication",
+        "operatingSystem": "Web",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
+    </script>
+
     <!-- FAQ Schema for SEO -->
     <script type="application/ld+json">
       {


### PR DESCRIPTION
- Add explicit WebApplication schema to index.html as per issue requirements.
  The existing SoftwareApplication schema is complemented by WebApplication
  which Google Search specifically recognizes for rich results.
- Update sitemap.xml lastmod dates to 2026-03-10 to reflect current content.

The meta description, robots.txt sitemap reference, and core structured data
(SoftwareApplication, FAQPage, HowTo, BreadcrumbList) were already in place.

https://claude.ai/code/session_01MnGPU6CA4NsXPCftA4NTmg