### PR TITLE
Rename Home to Convert in navigation menu

### DIFF
--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -1,10 +1,10 @@
 {
   "header.signIn": "Sign In",
   "header.signOut": "Sign Out",
-  "header.home": "Home",
+  "header.home": "Convert",
   "header.howItWorks": "How It Works",
   "header.tooltip.signIn": "Sign in with Google",
-  "header.tooltip.home": "Go to home page",
+  "header.tooltip.home": "Go to convert page",
   "header.tooltip.howItWorks": "Learn how it works",
   "header.tooltip.settings": "Settings",
   "header.tooltip.signOut": "Sign out of your account",

--- a/public/assets/i18n/fr.json
+++ b/public/assets/i18n/fr.json
@@ -1,10 +1,10 @@
 {
   "header.signIn": "Connexion",
   "header.signOut": "Déconnexion",
-  "header.home": "Accueil",
+  "header.home": "Convertir",
   "header.howItWorks": "Comment ça marche",
   "header.tooltip.signIn": "Se connecter avec Google",
-  "header.tooltip.home": "Aller à la page d'accueil",
+  "header.tooltip.home": "Aller à la page de conversion",
   "header.tooltip.howItWorks": "Découvrir comment ça marche",
   "header.tooltip.settings": "Paramètres",
   "header.tooltip.signOut": "Se déconnecter",

--- a/src/app/components/header/header.html
+++ b/src/app/components/header/header.html
@@ -89,7 +89,7 @@
               [appTooltip]="'header.tooltip.home' | translate"
               appTooltipPlacement="left"
             >
-              <i class="fas fa-home" aria-hidden="true"></i>
+              <i class="fas fa-exchange-alt" aria-hidden="true"></i>
               <span>{{ 'header.home' | translate }}</span>
             </a>
 


### PR DESCRIPTION
- EN: "Home" → "Convert", tooltip updated
- FR: "Accueil" → "Convertir", tooltip updated
- Icon changed from fa-home to fa-exchange-alt

https://claude.ai/code/session_01HqRZ7rzzQHXwVC1uzpPCir