### PR TITLE
Add cookie preferences link in footer

### DIFF
--- a/src/app/components/cookie-consent/cookie-consent.ts
+++ b/src/app/components/cookie-consent/cookie-consent.ts
@@ -2,6 +2,7 @@ import {
   Component,
   signal,
   OnInit,
+  effect,
   PLATFORM_ID,
   inject,
   ChangeDetectionStrategy,
@@ -10,6 +11,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { LocalizeRoutePipe } from '../../shared/pipes/localize-route.pipe';
+import { CookieConsentService } from '../../services/cookie-consent.service';
 
 const CONSENT_KEY = 'photocalia_cookie_consent';
 
@@ -30,11 +32,26 @@ export interface CookieConsentData {
 })
 export class CookieConsent implements OnInit {
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly cookieConsentService = inject(CookieConsentService);
 
   readonly visible = signal(false);
   readonly showDetails = signal(false);
   readonly analyticsEnabled = signal(true);
   readonly preferencesEnabled = signal(true);
+
+  constructor() {
+    effect(() => {
+      if (this.cookieConsentService.openRequested() > 0) {
+        const stored = this.getStoredConsent();
+        if (stored) {
+          this.analyticsEnabled.set(stored.analytics);
+          this.preferencesEnabled.set(stored.preferences);
+          this.showDetails.set(true);
+        }
+        this.visible.set(true);
+      }
+    });
+  }
 
   ngOnInit(): void {
     if (isPlatformBrowser(this.platformId)) {

--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -55,6 +55,9 @@
         >
           Version {{ appVersion }}
         </a>
+        <button class="footer-cookie-btn" type="button" (click)="openCookiePreferences()">
+          Cookie Preferences
+        </button>
       </div>
 
       <div class="footer-social">

--- a/src/app/components/footer/footer.scss
+++ b/src/app/components/footer/footer.scss
@@ -168,6 +168,26 @@
   }
 }
 
+.footer-cookie-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--ct-footer-text, #9ca3af);
+  transition: color 0.2s;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--ct-footer-link-hover, #ffffff);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ct-primary, #4f46e5);
+    outline-offset: 2px;
+  }
+}
+
 .footer-social {
   display: flex;
   align-items: center;

--- a/src/app/components/footer/footer.ts
+++ b/src/app/components/footer/footer.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { GithubService } from '../../services/github.service';
+import { CookieConsentService } from '../../services/cookie-consent.service';
 import { LocalizeRoutePipe } from '../../shared/pipes/localize-route.pipe';
 import { environment } from '../../../environments/environment';
 
@@ -41,6 +42,7 @@ export interface SocialLink {
 })
 export class Footer implements OnInit {
   private readonly githubService = inject(GithubService);
+  private readonly cookieConsentService = inject(CookieConsentService);
 
   currentYear = new Date().getFullYear();
   appVersion = environment.appVersion ?? '0.0.0';
@@ -170,6 +172,10 @@ export class Footer implements OnInit {
     if (legalLinks.length > 0) sections.push({ title: 'Legal', links: legalLinks });
 
     return sections;
+  }
+
+  openCookiePreferences(): void {
+    this.cookieConsentService.open();
   }
 
   /**

--- a/src/app/services/cookie-consent.service.ts
+++ b/src/app/services/cookie-consent.service.ts
@@ -1,0 +1,11 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class CookieConsentService {
+  private readonly _openRequested = signal(0);
+  readonly openRequested = this._openRequested.asReadonly();
+
+  open(): void {
+    this._openRequested.update((v) => v + 1);
+  }
+}


### PR DESCRIPTION
- Create CookieConsentService to allow reopening the banner from anywhere
- Update CookieConsent to react to the service and pre-load stored preferences on reopen
- Add "Cookie Preferences" button in footer bottom bar so users can change their choices at any time

https://claude.ai/code/session_01HqRZ7rzzQHXwVC1uzpPCir