### PR TITLE
fix: resolve Angular compilation error in AppTooltipDirective

### DIFF
--- a/src/app/shared/directives/app-tooltip.directive.ts
+++ b/src/app/shared/directives/app-tooltip.directive.ts
@@ -20,7 +20,7 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
   hostDirectives: [
     {
       directive: NgbTooltip,
-      inputs: ['ngbTooltip: appTooltip', 'placement: appTooltipPlacement'],
+      inputs: ['ngbTooltip: appTooltip'],
     },
   ],
 })
@@ -37,5 +37,6 @@ export class AppTooltipDirective implements OnInit {
     // Apply default configuration
     this.ngbTooltip.container = 'body';
     this.ngbTooltip.triggers = 'hover focus';
+    this.ngbTooltip.placement = this.appTooltipPlacement;
   }
 }


### PR DESCRIPTION
Remove 'placement: appTooltipPlacement' from hostDirectives inputs array to
eliminate the duplicate input declaration conflict. The same input name was
declared both via hostDirectives forwarding and as a local @Input(), causing
Angular compiler to crash with "Cannot read properties of undefined (reading
'passThroughInput')" and cascade failures on RouterOutlet, RouterLink, and
NgOptimizedImage.

Placement is now applied manually in ngOnInit via this.ngbTooltip.placement.

https://claude.ai/code/session_01MqgwZGf8LGWmtvpsTrN37B