### PR TITLE
Fix calendar scroll in week/day view on desktop

### DIFF
--- a/src/app/components/calendar-view/calendar-view.scss
+++ b/src/app/components/calendar-view/calendar-view.scss
@@ -2,6 +2,13 @@
    Calendar View — Modern Redesign
    ======================== */
 
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 /* ========================
    Shared Styles (Modal + Inline)
    ======================== */

--- a/src/app/components/calendar-view/calendar-view.scss
+++ b/src/app/components/calendar-view/calendar-view.scss
@@ -5,7 +5,6 @@
 :host {
   display: flex;
   flex-direction: column;
-  flex: 1;
   min-height: 0;
 }
 
@@ -186,7 +185,6 @@
 
 /* Calendar body — holds calendar + popover */
 .calendar-body {
-  flex: 1;
   min-height: 0;
   overflow: auto;
   position: relative;
@@ -342,7 +340,6 @@
    ======================== */
 .calendar-inline-container {
   position: relative;
-  flex: 1;
   min-height: 0;
   background: var(--ct-surface, #ffffff);
   border: 1px solid var(--ct-border, #e2e8f0);

--- a/src/app/components/calendar-view/calendar-view.scss
+++ b/src/app/components/calendar-view/calendar-view.scss
@@ -335,7 +335,8 @@
    ======================== */
 .calendar-inline-container {
   position: relative;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   background: var(--ct-surface, #ffffff);
   border: 1px solid var(--ct-border, #e2e8f0);
   border-radius: var(--radius-lg);

--- a/src/app/components/calendar-view/calendar-view.ts
+++ b/src/app/components/calendar-view/calendar-view.ts
@@ -139,6 +139,7 @@ export class CalendarView implements AfterViewInit {
       this.updateEventIndexForView(info.view.activeStart, info.view.activeEnd);
     },
     height: '100%',
+    contentHeight: 'auto',
     expandRows: true,
     scrollTime: '06:00:00',
     eventTimeFormat: {

--- a/src/app/components/calendar-view/calendar-view.ts
+++ b/src/app/components/calendar-view/calendar-view.ts
@@ -139,7 +139,6 @@ export class CalendarView implements AfterViewInit {
       this.updateEventIndexForView(info.view.activeStart, info.view.activeEnd);
     },
     height: '100%',
-    contentHeight: 'auto',
     expandRows: true,
     scrollTime: '06:00:00',
     eventTimeFormat: {

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -667,13 +667,6 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
-
-    app-calendar-view {
-      flex: 1;
-      min-height: 0;
-      display: flex;
-      flex-direction: column;
-    }
   }
 }
 

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -662,7 +662,6 @@
     // Sticky positioning on desktop so calendar stays visible while scrolling
     position: sticky;
     top: 2rem;
-    height: calc(100vh - 6rem);
     max-height: calc(100vh - 6rem);
     overflow: hidden;
     display: flex;

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -663,7 +663,9 @@
     position: sticky;
     top: 2rem;
     max-height: calc(100vh - 6rem);
-    overflow: visible;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
 }
 

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -662,10 +662,18 @@
     // Sticky positioning on desktop so calendar stays visible while scrolling
     position: sticky;
     top: 2rem;
+    height: calc(100vh - 6rem);
     max-height: calc(100vh - 6rem);
     overflow: hidden;
     display: flex;
     flex-direction: column;
+
+    app-calendar-view {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixed calendar not scrolling in week/day views on desktop
- `.calendar-card` had `overflow: visible` with a `max-height` constraint, which prevented the height from propagating to inner containers
- Changed to `overflow: hidden` with `display: flex; flex-direction: column` so the `.calendar-body`'s `overflow: auto` properly enables scrolling

## Test plan
- [ ] Open desktop view with calendar visible
- [ ] Switch to week view — verify the time grid scrolls properly
- [ ] Switch to day view — verify the time grid scrolls properly
- [ ] Verify month view still works as expected
- [ ] Verify calendar stays sticky when scrolling the page

https://claude.ai/code/session_01Wkk3meGVnw9z5WUyCnecuw