### PR TITLE
ci: add release notes config to exclude bot commits

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  exclude:
+    authors:
+      - github-actions[bot]
+      - dependabot[bot]
+    labels:
+      - ignore-for-release
+  categories:
+    - title: "🚀 New Features"
+      labels: [enhancement, feature]
+    - title: "🐛 Bug Fixes"
+      labels: [bug, fix]
+    - title: "📦 Dependencies"
+      labels: [dependencies]
+    - title: "🔧 Other Changes"
+      labels: ["*"]


### PR DESCRIPTION
## Summary
- Add `.github/release.yml` to exclude bot commits (`github-actions[bot]`, `dependabot[bot]`) from auto-generated release notes

## Test plan
- [ ] Trigger release workflow manually and verify no bot commits in notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)