### PR TITLE
feat: update API URLs to use /v1 versioned endpoints

### DIFF
--- a/scripts/set-env.js
+++ b/scripts/set-env.js
@@ -19,7 +19,7 @@ const appVersion = packageJson.version || '0.0.0';
 
 const envConfigFile = `export const environment = {
   production: true,
-  apiUrl: 'https://api.photocalia.com',
+  apiUrl: 'https://api.photocalia.com/v1',
   appVersion: '${appVersion}',
   firebase: {
     apiKey: '${apiKey}',

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  apiUrl: 'https://your-api-url.example.com',
+  apiUrl: 'https://your-api-url.example.com/v1',
   firebase: {
     apiKey: 'YOUR_FIREBASE_API_KEY',
     authDomain: 'your-project.firebaseapp.com',

--- a/src/environments/environment.prod.example.ts
+++ b/src/environments/environment.prod.example.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://your-api-url.example.com',
+  apiUrl: 'https://your-api-url.example.com/v1',
   firebase: {
     apiKey: 'YOUR_FIREBASE_API_KEY',
     authDomain: 'your-project.firebaseapp.com',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://api.photocalia.com',
+  apiUrl: 'https://api.photocalia.com/v1',
   appVersion: '4.7.0',
   firebase: {
     apiKey: 'AIzaSyDvQ4aCcWtSxGmTXefINTcsdb0O5zheYzE',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8080',
+  apiUrl: 'http://localhost:8080/v1',
   appVersion: '4.7.0',
   firebase: {
     apiKey: 'AIzaSyDvQ4aCcWtSxGmTXefINTcsdb0O5zheYzE',


### PR DESCRIPTION
## Summary
- Append `/v1` to `apiUrl` in all environment files to match the new versioned API endpoints in 3dime-api
- Affects: `environment.ts`, `environment.prod.ts`, `environment.example.ts`, `environment.prod.example.ts`, `scripts/set-env.js`

## Test plan
- [ ] Verify API calls go to `/v1/converter`, `/v1/converter/quota-status`, etc.
- [ ] Deploy simultaneously with m-idriss/3dime-api PR (breaking change coordination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)