### PR TITLE
feat(blog): Add date localization for blog articles

### DIFF
--- a/src/app/pages/blog/article/article.html
+++ b/src/app/pages/blog/article/article.html
@@ -22,7 +22,7 @@
           </span>
           <span class="meta-separator" aria-hidden="true">&bull;</span>
           <time itemprop="datePublished" [attr.datetime]="art.datePublished">
-            {{ art.datePublished }}
+            {{ art.datePublished | localizeDate }}
           </time>
           <span class="meta-separator" aria-hidden="true">&bull;</span>
           <span>{{ art.readingTime }} {{ 'blog.article.read' | translate }}</span>

--- a/src/app/pages/blog/article/article.ts
+++ b/src/app/pages/blog/article/article.ts
@@ -1,6 +1,7 @@
 import { Component, inject, OnInit, signal, computed } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { LocalizeRoutePipe } from '../../../shared/pipes/localize-route.pipe';
+import { LocalizeDatePipe } from '../../../shared/pipes/localize-date.pipe';
 import { TranslatePipe } from '../../../shared/pipes/translate.pipe';
 import { BLOG_ARTICLES, BlogArticle } from '../blog.models';
 import { PlanService } from '../../../services/plan.service';
@@ -8,7 +9,7 @@ import { PlanService } from '../../../services/plan.service';
 @Component({
   selector: 'app-article',
   standalone: true,
-  imports: [RouterLink, LocalizeRoutePipe, TranslatePipe],
+  imports: [RouterLink, LocalizeRoutePipe, LocalizeDatePipe, TranslatePipe],
   templateUrl: './article.html',
   styleUrl: './article.scss',
 })

--- a/src/app/pages/blog/blog.html
+++ b/src/app/pages/blog/blog.html
@@ -56,7 +56,7 @@
               </figure>
               <div class="article-meta">
                 <time [attr.datetime]="article.datePublished" class="article-date">
-                  {{ article.datePublished }}
+                  {{ article.datePublished | localizeDate }}
                 </time>
                 <span class="article-reading-time" aria-hidden="true">{{
                   article.readingTime

--- a/src/app/pages/blog/blog.ts
+++ b/src/app/pages/blog/blog.ts
@@ -2,6 +2,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { Component, OnInit, PLATFORM_ID, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { LocalizeRoutePipe } from '../../shared/pipes/localize-route.pipe';
+import { LocalizeDatePipe } from '../../shared/pipes/localize-date.pipe';
 import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { ScrollRevealDirective } from '../../shared/directives';
 import { BLOG_ARTICLES } from './blog.models';
@@ -13,7 +14,7 @@ const BLOG_VIEW_MODE_KEY = 'photocalia_blog_view_mode';
 @Component({
   selector: 'app-blog',
   standalone: true,
-  imports: [RouterLink, LocalizeRoutePipe, TranslatePipe, ScrollRevealDirective],
+  imports: [RouterLink, LocalizeRoutePipe, LocalizeDatePipe, TranslatePipe, ScrollRevealDirective],
   templateUrl: './blog.html',
   styleUrl: './blog.scss',
 })

--- a/src/app/shared/pipes/localize-date.pipe.spec.ts
+++ b/src/app/shared/pipes/localize-date.pipe.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { LocalizeDatePipe } from './localize-date.pipe';
+import { LanguageService } from '../../services/language.service';
+
+describe('LocalizeDatePipe', () => {
+  let pipe: LocalizeDatePipe;
+  let languageService: LanguageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [LocalizeDatePipe, LanguageService],
+    });
+
+    pipe = TestBed.inject(LocalizeDatePipe);
+    languageService = TestBed.inject(LanguageService);
+  });
+
+  it('should create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  describe('English format (YYYY-MM-DD)', () => {
+    beforeEach(() => {
+      languageService.currentLang.set('en');
+    });
+
+    it('should return date in YYYY-MM-DD format', () => {
+      const result = pipe.transform('2026-06-12');
+      expect(result).toBe('2026-06-12');
+    });
+
+    it('should handle various dates', () => {
+      expect(pipe.transform('2025-01-01')).toBe('2025-01-01');
+      expect(pipe.transform('2026-12-31')).toBe('2026-12-31');
+    });
+  });
+
+  describe('French format (DD-MM-YYYY)', () => {
+    beforeEach(() => {
+      languageService.currentLang.set('fr');
+    });
+
+    it('should convert to DD-MM-YYYY format', () => {
+      const result = pipe.transform('2026-06-12');
+      expect(result).toBe('12-06-2026');
+    });
+
+    it('should handle various dates', () => {
+      expect(pipe.transform('2025-01-01')).toBe('01-01-2025');
+      expect(pipe.transform('2026-12-31')).toBe('31-12-2026');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should return empty string for null', () => {
+      expect(pipe.transform(null)).toBe('');
+    });
+
+    it('should return empty string for undefined', () => {
+      expect(pipe.transform(undefined)).toBe('');
+    });
+
+    it('should return original string for invalid format', () => {
+      const invalidDate = 'not-a-date';
+      expect(pipe.transform(invalidDate)).toBe(invalidDate);
+    });
+
+    it('should handle dates with extra segments', () => {
+      const invalidDate = '2026-06-12-extra';
+      expect(pipe.transform(invalidDate)).toBe(invalidDate);
+    });
+  });
+});

--- a/src/app/shared/pipes/localize-date.pipe.ts
+++ b/src/app/shared/pipes/localize-date.pipe.ts
@@ -26,9 +26,9 @@ export class LocalizeDatePipe implements PipeTransform, OnDestroy {
     });
   }
 
-  transform(dateString: string): string {
-    if (!dateString || typeof dateString !== 'string') {
-      return dateString || '';
+  transform(dateString: string | null | undefined): string {
+    if (!dateString) {
+      return '';
     }
 
     // Expect YYYY-MM-DD format

--- a/src/app/shared/pipes/localize-date.pipe.ts
+++ b/src/app/shared/pipes/localize-date.pipe.ts
@@ -1,0 +1,55 @@
+import { Pipe, PipeTransform, inject, ChangeDetectorRef, OnDestroy } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { Subscription } from 'rxjs';
+import { LanguageService } from '../../services/language.service';
+
+/**
+ * Pipe that formats dates based on the current language.
+ * English: YYYY-MM-DD
+ * French: DD-MM-YYYY
+ *
+ * Usage: {{ '2026-06-12' | localizeDate }}
+ */
+@Pipe({
+  name: 'localizeDate',
+  standalone: true,
+  pure: false,
+})
+export class LocalizeDatePipe implements PipeTransform, OnDestroy {
+  private readonly languageService = inject(LanguageService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly sub: Subscription;
+
+  constructor() {
+    this.sub = toObservable(this.languageService.currentLang).subscribe(() => {
+      this.cdr.markForCheck();
+    });
+  }
+
+  transform(dateString: string): string {
+    if (!dateString || typeof dateString !== 'string') {
+      return dateString || '';
+    }
+
+    // Expect YYYY-MM-DD format
+    const parts = dateString.split('-');
+    if (parts.length !== 3) {
+      return dateString;
+    }
+
+    const [year, month, day] = parts;
+    const currentLang = this.languageService.currentLang();
+
+    if (currentLang === 'fr') {
+      // French format: DD-MM-YYYY
+      return `${day}-${month}-${year}`;
+    }
+
+    // English format: YYYY-MM-DD (no change)
+    return dateString;
+  }
+
+  ngOnDestroy(): void {
+    this.sub.unsubscribe();
+  }
+}


### PR DESCRIPTION
## Summary
Add language-aware date formatting for blog articles using a new LocalizeDatePipe with full type safety and test coverage.

## Changes

### New Pipe: LocalizeDatePipe
- **localize-date.pipe.ts**: Language-aware date formatter
  - English: YYYY-MM-DD format (default, no change)
  - French: DD-MM-YYYY format
  - Accepts nullable input (string | null | undefined) for template compatibility
  - Standalone, impure pipe that subscribes to language service changes
  - Automatically re-evaluates when user changes language

### Blog Components Updated
- **blog.ts**: Import and declare LocalizeDatePipe
- **blog.html**: Apply pipe to article publication date display
- **article.ts**: Import and declare LocalizeDatePipe
- **article.html**: Apply pipe to article publication date display

### Test Coverage
- **localize-date.pipe.spec.ts**: Comprehensive unit tests
  - ✅ English format (YYYY-MM-DD) preservation
  - ✅ French format conversion (DD-MM-YYYY)
  - ✅ Null/undefined handling
  - ✅ Invalid date format fallback
  - ✅ Edge case coverage

## Review Feedback Addressed
1. **Type Safety**: Fixed input type signature to accept `string | null | undefined` (Copilot comment 1)
2. **Test Coverage**: Added comprehensive unit tests for date formatting (Copilot comment 2)

## Example
Article published on 2026-06-12 displays as:
- 🇬🇧 English: "2026-06-12"
- 🇫🇷 French: "12-06-2026"

## Testing
- Date pipe transforms correctly for both EN/FR ✓
- Datetime attribute remains YYYY-MM-DD for semantic HTML ✓
- Null and invalid inputs handled gracefully ✓
- All unit tests passing ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)