### PR TITLE
fix(styles): Resolve Bootstrap SCSS import path for dev server

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,5 @@
 /* Importing Bootstrap SCSS file. */
-@use 'bootstrap/scss/bootstrap';
+@import '../node_modules/bootstrap/scss/bootstrap';
 
 /* Self-hosted Plus Jakarta Sans */
 @font-face {


### PR DESCRIPTION
## Problem
Dev server fails to start with error:
```
✘ [ERROR] Can't find stylesheet to import.
  ╷
2 │ @use 'bootstrap/scss/bootstrap';
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Root Cause
The `@use` statement with bare `bootstrap/scss/bootstrap` path was not being resolved correctly by the SASS compiler. The path resolver needs the full relative path to `node_modules`.

## Solution
Changed import statement from:
```scss
@use 'bootstrap/scss/bootstrap';
```

To:
```scss
@import '../node_modules/bootstrap/scss/bootstrap';
```

## Impact
- ✅ Fixes "Can't find stylesheet to import" error
- ✅ Dev server now starts successfully with `npm run dev`
- ✅ Bootstrap styles load correctly in development
- ✅ No breaking changes to app functionality

## Notes
- Bootstrap still generates SASS deprecation warnings (from Bootstrap's use of old SASS syntax), but these are non-blocking
- Once Bootstrap updates its SASS usage, deprecation warnings will resolve
- Tested on Node.js v26.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)