### PR TITLE
[codex] Hide redundant calendar event navigation

### DIFF
--- a/src/app/components/calendar-view/calendar-view.html
+++ b/src/app/components/calendar-view/calendar-view.html
@@ -26,7 +26,7 @@
             {{ 'calendar.title' | translate }}
           </h2>
           <div class="calendar-header-right">
-            @if (eventCount() > 1) {
+            @if (showEventNavigation()) {
               <span class="event-nav">
                 <button class="event-nav-btn" (click)="prevEvent()" aria-label="Previous event">
                   ◀
@@ -107,7 +107,7 @@
         <h2 id="calendar-inline-title" class="calendar-title">
           {{ 'calendar.title' | translate }}
         </h2>
-        @if (eventCount() > 1) {
+        @if (showEventNavigation()) {
           <div class="calendar-header-right">
             <span class="event-nav">
               <button class="event-nav-btn" (click)="prevEvent()" aria-label="Previous event">

--- a/src/app/components/calendar-view/calendar-view.spec.ts
+++ b/src/app/components/calendar-view/calendar-view.spec.ts
@@ -181,7 +181,35 @@ describe('CalendarView', () => {
     expect(fixture.nativeElement.textContent).toContain('AI-extracted events may contain errors');
   });
 
-  it('should show event navigation when there are multiple events', () => {
+  it('should hide event navigation when all events are visible in the current range', () => {
+    component = fixture.componentInstance;
+    component['currentViewRange'].set({
+      start: new Date('2025-01-01T00:00:00'),
+      end: new Date('2025-02-01T00:00:00'),
+    });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.event-nav-index')).toBeFalsy();
+  });
+
+  it('should show event navigation when events extend beyond the current range', async () => {
+    fixture = await createComponent({
+      events: [
+        mockEvents[0],
+        {
+          ...mockEvents[1],
+          start: new Date('2025-02-16T14:00:00'),
+          end: new Date('2025-02-16T15:00:00'),
+        },
+      ],
+    });
+    component = fixture.componentInstance;
+    component['currentViewRange'].set({
+      start: new Date('2025-01-01T00:00:00'),
+      end: new Date('2025-02-01T00:00:00'),
+    });
+    fixture.detectChanges();
+
     const eventNavIndex = fixture.nativeElement.querySelector(
       '.event-nav-index',
     ) as HTMLElement | null;

--- a/src/app/components/calendar-view/calendar-view.ts
+++ b/src/app/components/calendar-view/calendar-view.ts
@@ -82,6 +82,7 @@ export class CalendarView implements AfterViewInit {
   });
   // Current view date — updated when navigating the calendar
   protected readonly currentViewDate = signal('');
+  private readonly currentViewRange = signal<{ start: Date; end: Date } | null>(null);
 
   // Sorted events by date for navigation
   protected readonly sortedEvents = computed(() => {
@@ -98,6 +99,16 @@ export class CalendarView implements AfterViewInit {
 
   // Current event index for navigation
   protected readonly currentEventIndex = signal(0);
+  protected readonly showEventNavigation = computed(() => {
+    const events = this.sortedEvents();
+    const range = this.currentViewRange();
+    if (events.length <= 1 || !range) return false;
+
+    return events.some((event) => {
+      const date = event.start instanceof Date ? event.start : new Date(event.start);
+      return isNaN(date.getTime()) || date < range.start || date >= range.end;
+    });
+  });
 
   // Event detail popover
   protected readonly selectedEvent = signal<EventDetail | null>(null);
@@ -137,6 +148,10 @@ export class CalendarView implements AfterViewInit {
       this.currentViewDate.set(
         viewDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
       );
+      this.currentViewRange.set({
+        start: info.view.currentStart,
+        end: info.view.currentEnd,
+      });
       this.updateEventIndexForView(info.view.activeStart, info.view.activeEnd);
     },
     height: '100%',


### PR DESCRIPTION
## Summary

- hide the event `current/total` navigation when every event is already contained in the displayed month, week, or day
- keep the navigation visible when events extend beyond the current calendar period
- add focused tests for both visibility states

## Why

The header navigation was based only on the total number of events. This displayed controls such as `1/3` even when all three events were already visible together in the current calendar view, adding unnecessary information.

The visibility is now derived from FullCalendar’s exact current period boundaries.

## Validation

- `node_modules/.bin/ng test --watch=false --browsers=ChromeHeadless --include=src/app/components/calendar-view/calendar-view.spec.ts`
- 17 tests passed
- pre-commit ESLint and Prettier hooks passed
- `git diff --check` passed