### PR TITLE
[codex] Keep About SEO title consistent

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,7 +12,6 @@ const PRICING_TITLE = pageTitle('Pricing: Free, Pro & Business Plans');
 const SUBSCRIPTION_SUCCESS_TITLE = pageTitle('Subscription Activated');
 const DONATION_SUCCESS_TITLE = pageTitle('Thank You for Your Donation');
 const ABOUT_TITLE = pageTitle('About: AI Calendar Converter Built by Idriss');
-const FR_ABOUT_TITLE = pageTitle('À propos : convertisseur calendrier IA créé par Idriss');
 
 /**
  * Shared page route definitions used for both English (root) and French (/fr) paths.
@@ -449,46 +448,10 @@ const pageRoutes: Route[] = [
             ],
           },
         ],
-        localized: {
-          fr: {
-            title: pageTitle('À propos : convertisseur calendrier IA créé par Idriss'),
-            description:
-              "Découvrez PhotoCalia, le convertisseur photo vers calendrier propulsé par l'IA. Créé par Idriss avec Angular, Firebase et GPT-4 Vision. Open source, respectueux de la confidentialité et gratuit.",
-            keywords:
-              'à propos photocalia, convertisseur calendrier IA, application photo vers calendrier, Idriss, 3dime, outil calendrier open source',
-            ogImage: 'https://www.photocalia.com/assets/images/converter.png',
-            ogUrl: 'https://www.photocalia.com/fr/about',
-            type: 'website',
-            structuredData: [
-              {
-                '@context': 'https://schema.org',
-                '@type': 'BreadcrumbList',
-                itemListElement: [
-                  {
-                    '@type': 'ListItem',
-                    position: 1,
-                    name: 'Accueil',
-                    item: 'https://www.photocalia.com/fr',
-                  },
-                  {
-                    '@type': 'ListItem',
-                    position: 2,
-                    name: 'À propos',
-                    item: 'https://www.photocalia.com/fr/about',
-                  },
-                ],
-              },
-            ],
-          },
-        },
       },
     },
   },
 ];
-
-const frenchPageRoutes: Route[] = pageRoutes.map((route) =>
-  route.path === 'about' ? { ...route, title: FR_ABOUT_TITLE } : route,
-);
 
 export const routes: Routes = [
   // English routes (default)
@@ -497,7 +460,7 @@ export const routes: Routes = [
   // French routes under /fr prefix
   {
     path: 'fr',
-    children: [...frenchPageRoutes, { path: '**', redirectTo: '' }],
+    children: [...pageRoutes, { path: '**', redirectTo: '' }],
   },
 
   // Catch-all redirect

--- a/src/app/services/seo.service.ts
+++ b/src/app/services/seo.service.ts
@@ -14,7 +14,6 @@ export interface SeoData {
   author?: string;
   type?: string;
   structuredData?: object[];
-  localized?: Partial<Record<'fr', SeoData>>;
 }
 
 export const SITE_URL = 'https://www.photocalia.com';
@@ -59,15 +58,7 @@ export class SeoService {
       });
   }
 
-  updateSeoTags(seoData: SeoData) {
-    // Determine current path and canonical URL
-    const currentPath = this.normalizePath(this.router.url.split('?')[0].split('#')[0]);
-    const pagePath = this.stripLangPrefix(currentPath);
-    const canonicalUrl = `${SITE_URL}${currentPath === '/' ? '' : currentPath}`;
-    const seo = currentPath.startsWith(`${FR_PREFIX}/`)
-      ? seoData.localized?.fr || seoData
-      : seoData;
-
+  updateSeoTags(seo: SeoData) {
     // Set Title
     this.titleService.setTitle(seo.title);
 
@@ -82,6 +73,11 @@ export class SeoService {
     if (seo.author) {
       this.metaService.updateTag({ name: 'author', content: seo.author });
     }
+
+    // Determine current path and canonical URL
+    const currentPath = this.normalizePath(this.router.url.split('?')[0].split('#')[0]);
+    const pagePath = this.stripLangPrefix(currentPath);
+    const canonicalUrl = `${SITE_URL}${currentPath === '/' ? '' : currentPath}`;
 
     // Open Graph Tags
     this.metaService.updateTag({ property: 'og:title', content: seo.title });


### PR DESCRIPTION
## Summary

- Remove the French-only About SEO title/meta override added in #932.
- Keep French routes using the same shared English SEO title behavior as the rest of the site.
- Leave the visible /fr/about content translation intact.

## Context

After #932 was merged, we decided to keep this PR scoped to visible page translation only, because the other French pages do not currently have localized SEO titles.

## Validation

- Ran npm run build:ci with Node 22.22.3.
- First build attempt hit a transient esbuild deadlock; reran successfully.