### PR TITLE
Update Node.js version to 24 in workflow

### DIFF
--- a/.github/workflows/update-screenshot.yml
+++ b/.github/workflows/update-screenshot.yml
@@ -56,7 +56,7 @@ jobs:
         if: steps.changes.outputs.should_run == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by upgrading the Node.js version used in the `update-screenshot.yml` job from version 20 to 24. This ensures the workflow uses the latest Node.js features and security updates.