### PR TITLE
[codex] Add animated home use case strip

### DIFF
--- a/src/app/pages/home/home.html
+++ b/src/app/pages/home/home.html
@@ -58,6 +58,54 @@
       class="content-layout"
       [class.has-calendar]="calendarStateService.isVisible() && isDesktop()"
     >
+      @if (calendarStateService.events().length === 0) {
+        <div class="hero-blog-strip" aria-label="Use cases">
+          <div class="hero-blog-track">
+            <div class="hero-blog-group">
+              @for (article of featuredBlogArticles; track article.slug) {
+                @let localizedArticle = localized(article);
+                <a
+                  class="hero-blog-card"
+                  [routerLink]="blogArticlePath(article) | localizeRoute"
+                  [attr.aria-label]="localizedArticle.title"
+                >
+                  <img
+                    class="hero-blog-card-image"
+                    [src]="article.image"
+                    [alt]="localizedArticle.imageAlt"
+                    width="320"
+                    height="180"
+                    loading="lazy"
+                  />
+                  <span class="hero-blog-card-title">{{ localizedArticle.title }}</span>
+                </a>
+              }
+            </div>
+
+            <div class="hero-blog-group" aria-hidden="true">
+              @for (article of featuredBlogArticles; track article.slug) {
+                @let localizedArticle = localized(article);
+                <a
+                  class="hero-blog-card"
+                  tabindex="-1"
+                  [routerLink]="blogArticlePath(article) | localizeRoute"
+                >
+                  <img
+                    class="hero-blog-card-image"
+                    [src]="article.image"
+                    alt=""
+                    width="320"
+                    height="180"
+                    loading="lazy"
+                  />
+                  <span class="hero-blog-card-title">{{ localizedArticle.title }}</span>
+                </a>
+              }
+            </div>
+          </div>
+        </div>
+      }
+
       <div class="converter-card">
         <app-converter></app-converter>
       </div>

--- a/src/app/pages/home/home.scss
+++ b/src/app/pages/home/home.scss
@@ -695,6 +695,7 @@
    ======================== */
 .content-layout {
   display: grid;
+  position: relative;
   width: 100%;
   max-width: 1280px;
   margin: 0 auto;
@@ -719,6 +720,26 @@
   @media (min-width: 1200px) {
     grid-template-columns: 1fr;
     justify-items: center;
+  }
+
+  @media (min-width: 1200px) {
+    &:not(.has-calendar) {
+      grid-template-columns: minmax(190px, 260px) minmax(420px, 560px) minmax(190px, 260px);
+      column-gap: clamp(1rem, 2vw, 2rem);
+      justify-content: center;
+
+      .converter-card,
+      .powered-badge,
+      .compatible-strip,
+      .quota-status-bar,
+      .hero-subtitle {
+        grid-column: 2;
+      }
+
+      .hero-blog-strip {
+        grid-column: 1 / -1;
+      }
+    }
   }
 
   // Desktop: Side-by-side layout when calendar is visible
@@ -752,6 +773,10 @@
         grid-column: 2;
         grid-row: 1 / -1;
       }
+
+      .hero-blog-strip {
+        display: none;
+      }
     }
   }
 
@@ -761,7 +786,126 @@
   }
 }
 
+.hero-blog-strip {
+  display: none;
+
+  @media (min-width: 1200px) {
+    display: block;
+    position: absolute;
+    top: clamp(2.4rem, 4vw, 3.25rem);
+    left: 50%;
+    z-index: 0;
+    width: min(100vw, 1280px);
+    overflow: hidden;
+    transform: translateX(-50%);
+    pointer-events: none;
+    mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
+    -webkit-mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);
+  }
+
+  &::after {
+    @media (min-width: 1200px) {
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      background: radial-gradient(
+        ellipse at center,
+        rgba(248, 250, 252, 0.94) 0%,
+        rgba(248, 250, 252, 0.78) 22%,
+        rgba(248, 250, 252, 0.28) 46%,
+        transparent 68%
+      );
+      content: '';
+      pointer-events: none;
+    }
+  }
+}
+
+.hero-blog-track {
+  display: flex;
+  width: max-content;
+  gap: 1rem;
+  animation: scrollHeroUseCases 42s linear infinite;
+}
+
+.hero-blog-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.hero-blog-card {
+  overflow: hidden;
+  width: 220px;
+  flex: 0 0 220px;
+  color: inherit;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(255, 255, 255, 0.58);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.045);
+  opacity: 0.72;
+  pointer-events: auto;
+  backdrop-filter: blur(2px);
+  transition:
+    border-color var(--t-fast),
+    box-shadow var(--t-fast),
+    opacity var(--t-fast);
+
+  &:hover,
+  &:focus-visible {
+    color: inherit;
+    border-color: rgba(255, 255, 255, 0.82);
+    box-shadow: 0 14px 34px rgba(15, 23, 42, 0.065);
+    opacity: 0.9;
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(79, 70, 229, 0.25);
+    outline-offset: 3px;
+  }
+}
+
+@keyframes scrollHeroUseCases {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(calc(-50% - 0.5rem));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-blog-track {
+    animation: none;
+    transform: translateX(-10%);
+  }
+}
+
+.hero-blog-card-image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  object-fit: cover;
+  background: #eef2ff;
+}
+
+.hero-blog-card-title {
+  display: -webkit-box;
+  margin: 0.7rem 0.8rem 0.85rem;
+  overflow: hidden;
+  color: var(--text-primary, #0f172a);
+  font-size: 0.84rem;
+  font-weight: 750;
+  line-height: 1.25;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
 .converter-card {
+  position: relative;
+  z-index: 2;
   width: 100%;
   margin-block: 0;
 
@@ -771,6 +915,14 @@
       max-width: 900px;
     }
   }
+}
+
+.powered-badge,
+.compatible-strip,
+.quota-status-bar,
+.hero-subtitle {
+  position: relative;
+  z-index: 2;
 }
 
 .calendar-card {

--- a/src/app/pages/home/home.spec.ts
+++ b/src/app/pages/home/home.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
 
 import { Home } from './home';
 import { AuthService } from '../../services/auth.service';
@@ -12,7 +13,7 @@ describe('Home', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [Home],
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Home);

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -28,6 +28,7 @@ import { TranslatePipe } from '../../shared/pipes/translate.pipe';
 import { LocalizeRoutePipe } from '../../shared/pipes/localize-route.pipe';
 import { ScrollRevealDirective } from '../../shared/directives';
 import { RouterLink } from '@angular/router';
+import { BLOG_ARTICLES, BlogArticle } from '../blog/blog.models';
 
 @Component({
   selector: 'app-home',
@@ -65,6 +66,9 @@ export class Home implements OnInit, AfterViewInit, OnDestroy {
     () =>
       `/assets/videos/photocalia-summer-campaign-${this.languageService.currentLang()}-poster.jpg`,
   );
+  protected readonly featuredBlogArticles = [...BLOG_ARTICLES]
+    .sort((a, b) => b.datePublished.localeCompare(a.datePublished))
+    .slice(0, 8);
 
   protected readonly isDesktop = signal(false);
   private resizeSubscription?: Subscription;
@@ -127,5 +131,13 @@ export class Home implements OnInit, AfterViewInit, OnDestroy {
    */
   handleCalendarExport(): void {
     this.calendarStateService.requestExport();
+  }
+
+  protected blogArticlePath(article: BlogArticle): string {
+    return `/blog/${article.slug}`;
+  }
+
+  protected localized(article: BlogArticle) {
+    return article.locales[this.languageService.currentLang()];
   }
 }


### PR DESCRIPTION
## Summary
- Add an animated desktop use-case strip behind the main home converter card.
- Source the strip from recent blog articles so new use cases appear automatically through generated blog metadata.
- Keep the effect desktop-only, hidden when the calendar preview is active, and respectful of reduced-motion preferences.
- Update the Home unit test router setup for the new localized article links.

## Validation
- npm run test:ci -- --include src/app/pages/home/home.spec.ts
- npm run build:ci
- git diff --check