### PR TITLE
[codex] Fix screenshot auto-merge CI

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,6 +1,7 @@
 name: Frontend CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -9,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: frontend-ci-${{ github.event.pull_request.number }}
+  group: frontend-ci-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update-screenshot.yml
+++ b/.github/workflows/update-screenshot.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      actions: write
       contents: write
       pull-requests: write
 
@@ -196,7 +197,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          commit-message: Update screenshots [skip ci]
+          commit-message: Update screenshots
           branch: update-screenshots-assets
           base: main
           title: Update screenshots
@@ -204,12 +205,46 @@ jobs:
           add-paths: public/assets/screenshots/
           labels: ''
 
+      - name: Run required Frontend CI
+        if: steps.changes.outputs.should_run == 'true' && steps.compare.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-number
+        run: |
+          set -euo pipefail
+
+          gh workflow run frontend-ci.yml --ref update-screenshots-assets
+
+          echo "Waiting for Frontend CI workflow_dispatch run on ${{ steps.cpr.outputs.pull-request-head-sha }}..."
+          RUN_ID=""
+          for _ in {1..30}; do
+            RUN_ID=$(gh run list \
+              --workflow frontend-ci.yml \
+              --branch update-screenshots-assets \
+              --event workflow_dispatch \
+              --commit "${{ steps.cpr.outputs.pull-request-head-sha }}" \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')
+
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+
+            sleep 5
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "Could not find the dispatched Frontend CI run for the screenshot PR."
+            exit 1
+          fi
+
+          gh run watch "$RUN_ID" --exit-status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-merge Pull Request (squash with fixed message)
         if: steps.changes.outputs.should_run == 'true' && steps.compare.outputs.has_changes == 'true' && steps.cpr.outputs.pull-request-number
         run: |
           gh pr merge ${{ steps.cpr.outputs.pull-request-number }} \
             --squash \
-            --admin \
             --delete-branch \
             --body "Update screenshots [skip ci]" \
             --subject "Update screenshots [skip ci]"


### PR DESCRIPTION
## Summary
- Make Frontend CI dispatchable so the screenshot workflow can run the required check on bot-created screenshot branches.
- Remove `[skip ci]` from the generated screenshot PR commit so checks are not suppressed.
- Wait for the dispatched Frontend CI run before merging the generated screenshot PR, while keeping `[skip ci]` on the final squash merge commit.

## Root cause
The scheduled screenshot workflow created PR #949 with a `[skip ci]` commit and then immediately tried to merge it. Branch protection requires `Lint, test, and build`, but that check never appeared, so GitHub rejected the merge.

## Validation
- Parsed the edited workflow YAML files with Python/PyYAML.
- Ran `git diff --check`.
- Could not run Angular lint locally because dependencies are not installed in the checkout (`ng: not found`).