### PR TITLE
[codex] Fix release semver comparison

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
           MAJOR="${VERSION_PARTS[0]:-0}"
           MINOR="${VERSION_PARTS[1]:-0}"
           PATCH="${VERSION_PARTS[2]:-0}"
+          CURRENT_MAJOR="$MAJOR"
+          CURRENT_MINOR="$MINOR"
+          CURRENT_PATCH="$PATCH"
 
           if [ "$VERSION_TYPE" = "custom" ]; then
             if [ -z "$CUSTOM_VERSION" ]; then
@@ -120,9 +123,9 @@ jobs:
           NEW_MINOR="${NEW_VERSION_PARTS[1]:-0}"
           NEW_PATCH="${NEW_VERSION_PARTS[2]:-0}"
 
-          if (( 10#$NEW_MAJOR < 10#$MAJOR )) ||
-             (( 10#$NEW_MAJOR == 10#$MAJOR && 10#$NEW_MINOR < 10#$MINOR )) ||
-             (( 10#$NEW_MAJOR == 10#$MAJOR && 10#$NEW_MINOR == 10#$MINOR && 10#$NEW_PATCH <= 10#$PATCH )); then
+          if (( 10#$NEW_MAJOR < 10#$CURRENT_MAJOR )) ||
+             (( 10#$NEW_MAJOR == 10#$CURRENT_MAJOR && 10#$NEW_MINOR < 10#$CURRENT_MINOR )) ||
+             (( 10#$NEW_MAJOR == 10#$CURRENT_MAJOR && 10#$NEW_MINOR == 10#$CURRENT_MINOR && 10#$NEW_PATCH <= 10#$CURRENT_PATCH )); then
             echo "Error: New version $NEW_VERSION must be greater than current version $CURRENT_VERSION"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Fix the release workflow version comparison so calculated versions are checked against the original current version, not the already-incremented version parts.

## Root cause

The workflow stores MAJOR, MINOR, and PATCH from the current version, then mutates them while calculating the new version. The validation later compared NEW_* against those mutated values, causing a minor bump from 4.9.1 to 4.10.0 to be treated as not greater because both sides had become 4.10.0.

## Validation

- Verified locally that 4.9.1 -> 4.10.0 passes.
- Verified locally that 4.9.1 -> 4.9.1 still fails.
- Ran git diff --check.