### PR TITLE
[codex] Add converter idempotency keys

### DIFF
--- a/src/app/services/converter.spec.ts
+++ b/src/app/services/converter.spec.ts
@@ -79,6 +79,40 @@ describe('ConverterService', () => {
     expect(req.request.body.userId).toBeTruthy();
     expect(req.request.body.userId).toContain('anon_');
     expect(req.request.body.files).toEqual(testFiles);
+    expect(req.request.headers.get('Idempotency-Key')).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('should use a new idempotency key for each conversion', () => {
+    const testFiles: FileData[] = [
+      { dataUrl: 'data:image/png;base64,test', name: 'test.png', type: 'image/png' },
+    ];
+
+    service.convertToIcs(testFiles).subscribe();
+    service.convertToIcs(testFiles).subscribe();
+
+    const requests = httpMock.match(`${environment.apiUrl}/converter`);
+    expect(requests.length).toBe(2);
+    expect(requests[0].request.headers.get('Idempotency-Key')).not.toBe(
+      requests[1].request.headers.get('Idempotency-Key'),
+    );
+  });
+
+  it('should reuse the idempotency key when the same conversion request is retried', () => {
+    const testFiles: FileData[] = [
+      { dataUrl: 'data:image/png;base64,test', name: 'test.png', type: 'image/png' },
+    ];
+    const conversionRequest = service.convertToIcs(testFiles);
+
+    conversionRequest.subscribe();
+    conversionRequest.subscribe();
+
+    const requests = httpMock.match(`${environment.apiUrl}/converter`);
+    expect(requests.length).toBe(2);
+    expect(requests[0].request.headers.get('Idempotency-Key')).toBe(
+      requests[1].request.headers.get('Idempotency-Key'),
+    );
   });
 
   it('maps simple remaining/limit shape to normalized response', fakeAsync(() => {

--- a/src/app/services/converter.ts
+++ b/src/app/services/converter.ts
@@ -431,7 +431,11 @@ export class ConverterService {
       userId: this.userId,
     };
 
-    return this.http.post<ConversionResponse>(`${this.baseUrl}/converter`, request);
+    const idempotencyKey = crypto.randomUUID();
+
+    return this.http.post<ConversionResponse>(`${this.baseUrl}/converter`, request, {
+      headers: { 'Idempotency-Key': idempotencyKey },
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

- add a UUID v4 `Idempotency-Key` header to every converter request
- reuse the key when the same cold request observable is subscribed to again
- generate a fresh key for each new logical conversion request
- cover header format, uniqueness, and retry reuse with unit tests

## Why

`m-idriss/3dime-api#224` makes quota reservation atomic and idempotent and requires `Idempotency-Key` on `POST /v1/converter`. Without this frontend change, conversions receive `400 Bad Request` after that backend release.

## Rollout

This PR must deploy after the API allows `idempotency-key` in CORS and before API PR `m-idriss/3dime-api#224` begins requiring the header. The CORS allowance is being isolated as a backwards-compatible prerequisite so this does not require a lockstep deployment.

## Validation

- `npm run lint`
- `npm run test:ci` (238 tests)
- `npm run build:ci`

## Related

- m-idriss/3dime-api#212
- m-idriss/3dime-api#224
