### PR TITLE
Send stable installation identity for free quota

### DIFF
--- a/contracts/3dime-api/openapi-v1.json
+++ b/contracts/3dime-api/openapi-v1.json
@@ -432,6 +432,15 @@
         "tags": [
           "converter"
         ],
+        "parameters": [
+          {
+            "name": "X-Installation-ID",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -455,6 +464,16 @@
           },
           "400": {
             "description": "Invalid request data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Verified Google authentication required",
             "content": {
               "application/json": {
                 "schema": {
@@ -575,6 +594,13 @@
               "type": "string"
             },
             "required": true
+          },
+          {
+            "name": "X-Installation-ID",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -584,6 +610,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QuotaStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Verified Google authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -99,6 +99,7 @@ test.describe('Converter', () => {
       });
     });
     await page.route('**/v1/converter/quota-status?*', async (route) => {
+      expect(route.request().headers()['x-installation-id']).toMatch(/^[A-Za-z0-9_-]{20,128}$/);
       await route.fulfill({
         contentType: 'application/json',
         body: JSON.stringify({
@@ -110,6 +111,7 @@ test.describe('Converter', () => {
     });
     await page.route('**/v1/converter', async (route) => {
       const request = route.request().postDataJSON() as { timeZone?: string; files?: unknown[] };
+      expect(route.request().headers()['x-installation-id']).toMatch(/^[A-Za-z0-9_-]{20,128}$/);
       expect(request.timeZone).toBe(goldenCase!.timeZone);
       expect(request.files).toHaveLength(1);
       await route.fulfill({

--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -410,7 +410,7 @@
   "pricing.billing.billed_yearly": "Billed €{total}/year",
   "pricing.plan.free.name": "Free",
   "pricing.plan.free.description": "Perfect for occasional use",
-  "pricing.plan.free.quota": "{limit} conversions / month",
+  "pricing.plan.free.quota": "{limit} conversions / month per account and browser",
   "pricing.plan.free.cta": "Get started free",
   "pricing.plan.pro.name": "Pro",
   "pricing.plan.pro.description": "For regular users who need more",

--- a/public/assets/i18n/fr.json
+++ b/public/assets/i18n/fr.json
@@ -410,7 +410,7 @@
   "pricing.billing.billed_yearly": "Facturé {total} €/an",
   "pricing.plan.free.name": "Gratuit",
   "pricing.plan.free.description": "Idéal pour un usage occasionnel",
-  "pricing.plan.free.quota": "{limit} conversions / mois",
+  "pricing.plan.free.quota": "{limit} conversions / mois par compte et navigateur",
   "pricing.plan.free.cta": "Commencer gratuitement",
   "pricing.plan.pro.name": "Pro",
   "pricing.plan.pro.description": "Pour les utilisateurs réguliers qui ont besoin de plus",

--- a/src/app/generated/3dime-api.ts
+++ b/src/app/generated/3dime-api.ts
@@ -20,7 +20,9 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    "X-Installation-ID"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
@@ -41,6 +43,15 @@ export interface paths {
                 };
                 /** @description Invalid request data */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description Verified Google authentication required */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -174,7 +185,9 @@ export interface paths {
                 query: {
                     userId: string;
                 };
-                header?: never;
+                header?: {
+                    "X-Installation-ID"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
@@ -187,6 +200,15 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["QuotaStatusResponse"];
+                    };
+                };
+                /** @description Verified Google authentication required */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
                     };
                 };
                 /** @description User not found */

--- a/src/app/pages/privacy/privacy.html
+++ b/src/app/pages/privacy/privacy.html
@@ -11,7 +11,7 @@
           <span class="legal-icon" aria-hidden="true">🔒</span>
           Politique de confidentialité
         </h1>
-        <p class="legal-subtitle">Dernière mise à jour : 7 août 2026</p>
+        <p class="legal-subtitle">Dernière mise à jour : 10 août 2026</p>
       </section>
 
       <section class="legal-content">
@@ -58,6 +58,14 @@
             Google Cloud traitent des données techniques telles que l'adresse IP, les journaux de
             requêtes et les caractéristiques du navigateur pour héberger et sécuriser le service.
             Vercel Analytics n'est activé qu'après votre consentement.
+          </p>
+          <p>
+            Pour empêcher le contournement répété de l'offre gratuite, PhotoCalia crée dans votre
+            navigateur un identifiant d'installation aléatoire, strictement nécessaire à la sécurité
+            du service. L'API conserve uniquement des empreintes HMAC pseudonymisées de cet
+            identifiant, du compte et, pour un garde-fou quotidien partagé, du réseau. Les
+            identifiants bruts et l'adresse IP brute ne sont pas enregistrés dans ces compteurs de
+            quota.
           </p>
         </div>
 
@@ -146,6 +154,11 @@
               compte ou les obligations opérationnelles associées existent.
             </li>
             <li>
+              <strong>Compteurs anti-abus pseudonymisés :</strong> les compteurs d'installation
+              suivent la période mensuelle de l'offre gratuite ; les garde-fous réseau et capacité
+              suivent une période quotidienne. Leur suppression technique peut être asynchrone.
+            </li>
+            <li>
               <strong>Suivi Notion :</strong> conservé pour la sécurité, le support et les mesures
               d'usage jusqu'à suppression ou anonymisation dans le cadre d'une demande vérifiée. Il
               n'existe pas actuellement d'expiration automatique courte pour ces entrées.
@@ -209,7 +222,7 @@
           <span class="legal-icon" aria-hidden="true">🔒</span>
           Privacy Policy
         </h1>
-        <p class="legal-subtitle">Last updated: August 7, 2026</p>
+        <p class="legal-subtitle">Last updated: August 10, 2026</p>
       </section>
 
       <section class="legal-content">
@@ -253,6 +266,13 @@
             Cloud process technical data such as IP addresses, request logs and browser
             characteristics to host and secure the service. Vercel Analytics is enabled only after
             you consent.
+          </p>
+          <p>
+            To prevent repeated circumvention of the free allowance, PhotoCalia creates a random
+            installation identifier in your browser that is strictly necessary for service security.
+            The API retains only pseudonymized HMAC fingerprints of that identifier, the account
+            and, for a shared daily safeguard, the network. Raw identifiers and the raw IP address
+            are not stored in these quota counters.
           </p>
         </div>
 
@@ -336,6 +356,11 @@
             <li>
               <strong>Account and quota data:</strong> retained in Firebase/Firestore while the
               account or associated operational obligations remain active.
+            </li>
+            <li>
+              <strong>Pseudonymized anti-abuse counters:</strong> installation counters follow the
+              free plan's monthly period; network and service-capacity safeguards follow a daily
+              period. Their technical deletion may occur asynchronously.
             </li>
             <li>
               <strong>Notion tracking:</strong> retained for security, support and usage measurement

--- a/src/app/pages/terms/terms.html
+++ b/src/app/pages/terms/terms.html
@@ -5,7 +5,7 @@
         <span class="legal-icon" aria-hidden="true">📋</span>
         Terms of Use
       </h1>
-      <p class="legal-subtitle">Last Updated: February 11, 2026</p>
+      <p class="legal-subtitle">Last Updated: August 10, 2026</p>
     </section>
 
     <section class="legal-content">
@@ -60,10 +60,18 @@
         <h3>4.1 Free Tier</h3>
         <p>Free users receive:</p>
         <ul>
-          <li>{{ freePlanLimit() }} free calendar conversions per month</li>
+          <li>
+            {{ freePlanLimit() }} free calendar conversions per month, jointly limited by verified
+            account and browser installation
+          </li>
           <li>Basic event extraction features</li>
           <li>Standard support</li>
         </ul>
+        <p>
+          Temporary network and service-capacity safeguards may also apply when repeated
+          multi-account use indicates circumvention. Failed conversions are not deducted. Paid
+          subscription quotas are not subject to the free installation allowance.
+        </p>
 
         <h3>4.2 Premium Tier (Future)</h3>
         <p>

--- a/src/app/services/converter-api-client.service.ts
+++ b/src/app/services/converter-api-client.service.ts
@@ -3,22 +3,32 @@ import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { ConversionRequest, ConversionResponse, PlanInfo } from '../models/converter-api.model';
+import { InstallationIdentityService } from './installation-identity.service';
 
 @Injectable({ providedIn: 'root' })
 export class ConverterApiClient {
   private readonly http = inject(HttpClient);
+  private readonly installationIdentity = inject(InstallationIdentityService);
   private readonly baseUrl = `${environment.apiUrl}/converter`;
 
   convert(request: ConversionRequest, idempotencyKey: string): Observable<ConversionResponse> {
     return this.http.post<ConversionResponse>(this.baseUrl, request, {
-      headers: { 'Idempotency-Key': idempotencyKey },
+      headers: {
+        'Idempotency-Key': idempotencyKey,
+        'X-Installation-ID': this.installationIdentity.getId(),
+      },
     });
   }
 
   getQuotaStatus(userId: string, headers: Record<string, string>): Observable<unknown> {
     return this.http.get<unknown>(
       `${this.baseUrl}/quota-status?userId=${encodeURIComponent(userId)}`,
-      { headers },
+      {
+        headers: {
+          ...headers,
+          'X-Installation-ID': this.installationIdentity.getId(),
+        },
+      },
     );
   }
 

--- a/src/app/services/converter.spec.ts
+++ b/src/app/services/converter.spec.ts
@@ -7,6 +7,7 @@ import { Auth } from '@angular/fire/auth';
 import { ConverterService, FileData, QuotaStatusResponse } from './converter';
 import { AuthService } from './auth.service';
 import { environment } from '../../environments/environment';
+import { InstallationIdentityService } from './installation-identity.service';
 
 describe('ConverterService', () => {
   let service: ConverterService;
@@ -82,6 +83,7 @@ describe('ConverterService', () => {
     expect(req.request.headers.get('Idempotency-Key')).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
     );
+    expect(req.request.headers.get('X-Installation-ID')).toMatch(/^[A-Za-z0-9_-]{20,128}$/);
   });
 
   it('should use a new idempotency key for each conversion', () => {
@@ -126,6 +128,7 @@ describe('ConverterService', () => {
     flushMicrotasks();
     const req = httpMock.expectOne((r) => r.url.includes('/converter/quota-status'));
     expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('X-Installation-ID')).toMatch(/^[A-Za-z0-9_-]{20,128}$/);
     req.flush(mock);
     flushMicrotasks();
 
@@ -155,9 +158,11 @@ describe('ConverterService', () => {
       enabled: true,
       quota: { usageCount: 2, limit: 10, remaining: 8, plan: 'FREE' },
     };
+    const installationId = TestBed.inject(InstallationIdentityService).getId();
+    const userId = service.getUserId();
     localStorage.setItem(
-      'photocalia_quota_cache_v1',
-      JSON.stringify({ ts: Date.now(), data: cached }),
+      'photocalia_quota_cache_v2',
+      JSON.stringify({ ts: Date.now(), userId, installationId, data: cached }),
     );
     let response: QuotaStatusResponse | undefined;
 

--- a/src/app/services/installation-identity.service.spec.ts
+++ b/src/app/services/installation-identity.service.spec.ts
@@ -1,0 +1,28 @@
+import { TestBed } from '@angular/core/testing';
+import { InstallationIdentityService } from './installation-identity.service';
+
+describe('InstallationIdentityService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+  });
+
+  it('persists one opaque identifier across service instances', () => {
+    const first = TestBed.inject(InstallationIdentityService).getId();
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    const second = TestBed.inject(InstallationIdentityService).getId();
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^[A-Za-z0-9_-]{20,128}$/);
+  });
+
+  it('replaces an invalid stored identifier', () => {
+    localStorage.setItem('photocalia_installation_id_v1', 'invalid');
+
+    const identifier = TestBed.inject(InstallationIdentityService).getId();
+
+    expect(identifier).not.toBe('invalid');
+    expect(identifier.length).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/src/app/services/installation-identity.service.ts
+++ b/src/app/services/installation-identity.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+
+const STORAGE_KEY = 'photocalia_installation_id_v1';
+const VALID_INSTALLATION_ID = /^[A-Za-z0-9_-]{20,128}$/;
+
+@Injectable({ providedIn: 'root' })
+export class InstallationIdentityService {
+  private installationId: string | null = null;
+
+  getId(): string {
+    if (this.installationId) return this.installationId;
+
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored && VALID_INSTALLATION_ID.test(stored)) {
+        this.installationId = stored;
+        return stored;
+      }
+    } catch {
+      // Private browsing and SSR can make storage unavailable.
+    }
+
+    this.installationId = this.createId();
+    try {
+      localStorage.setItem(STORAGE_KEY, this.installationId);
+    } catch {
+      // The in-memory identifier still keeps requests stable for this session.
+    }
+    return this.installationId;
+  }
+
+  private createId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    return `inst_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 15)}`;
+  }
+}

--- a/src/app/services/installation-identity.service.ts
+++ b/src/app/services/installation-identity.service.ts
@@ -30,9 +30,17 @@ export class InstallationIdentityService {
   }
 
   private createId(): string {
-    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-      return crypto.randomUUID();
+    const secureRandom = globalThis.crypto;
+    if (typeof secureRandom?.randomUUID === 'function') {
+      return secureRandom.randomUUID();
     }
-    return `inst_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 15)}`;
+
+    if (typeof secureRandom?.getRandomValues === 'function') {
+      const bytes = secureRandom.getRandomValues(new Uint8Array(16));
+      const hex = Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('');
+      return `inst_${hex}`;
+    }
+
+    throw new Error('Secure random generation is unavailable');
   }
 }

--- a/src/app/services/quota.service.ts
+++ b/src/app/services/quota.service.ts
@@ -4,6 +4,7 @@ import { Observable, catchError, from, map, of, switchMap } from 'rxjs';
 import { QuotaStatus, QuotaStatusResponse } from '../models/converter-api.model';
 import { AuthService } from './auth.service';
 import { ConverterApiClient } from './converter-api-client.service';
+import { InstallationIdentityService } from './installation-identity.service';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -15,16 +16,17 @@ export class QuotaService {
   private readonly authService = inject(AuthService);
   private readonly auth = inject(Auth, { optional: true });
   private readonly api = inject(ConverterApiClient);
-  private readonly cacheKey = 'photocalia_quota_cache_v1';
+  private readonly installationIdentity = inject(InstallationIdentityService);
+  private readonly cacheKey = 'photocalia_quota_cache_v2';
   private readonly cacheTtlMs = 1000 * 60 * 60 * 24;
   private userId = this.determineUserId();
 
   constructor() {
     effect(() => {
       const user = this.authService.currentUser();
-      const nextId = user?.email ?? user?.uid ?? this.getOrCreateAnonymousId();
+      const nextId = user?.uid ?? user?.email ?? this.getOrCreateAnonymousId();
       if (nextId === this.userId) return;
-      if (!user) this.clearCache();
+      this.clearCache();
       this.userId = nextId;
     });
   }
@@ -52,6 +54,7 @@ export class QuotaService {
   clearCache(): void {
     try {
       localStorage.removeItem(this.cacheKey);
+      localStorage.removeItem('photocalia_quota_cache_v1');
     } catch {
       // Storage can be unavailable during SSR or in privacy modes.
     }
@@ -59,7 +62,7 @@ export class QuotaService {
 
   private determineUserId(): string {
     const user = this.authService.currentUser();
-    return user?.email ?? user?.uid ?? this.getOrCreateAnonymousId();
+    return user?.uid ?? user?.email ?? this.getOrCreateAnonymousId();
   }
 
   private getOrCreateAnonymousId(): string {
@@ -155,7 +158,15 @@ export class QuotaService {
 
   private saveCache(response: QuotaStatusResponse): void {
     try {
-      localStorage.setItem(this.cacheKey, JSON.stringify({ ts: Date.now(), data: response }));
+      localStorage.setItem(
+        this.cacheKey,
+        JSON.stringify({
+          ts: Date.now(),
+          userId: this.userId,
+          installationId: this.installationIdentity.getId(),
+          data: response,
+        }),
+      );
     } catch {
       // Storage is best effort.
     }
@@ -165,8 +176,15 @@ export class QuotaService {
     try {
       const raw = localStorage.getItem(this.cacheKey);
       if (!raw) return null;
-      const parsed = JSON.parse(raw) as { ts?: unknown; data?: unknown };
+      const parsed = JSON.parse(raw) as {
+        ts?: unknown;
+        userId?: unknown;
+        installationId?: unknown;
+        data?: unknown;
+      };
       if (typeof parsed.ts !== 'number' || Date.now() - parsed.ts > this.cacheTtlMs) return null;
+      if (parsed.userId !== this.userId) return null;
+      if (parsed.installationId !== this.installationIdentity.getId()) return null;
       return parsed.data as QuotaStatusResponse;
     } catch {
       return null;


### PR DESCRIPTION
## Summary
- send a stable random installation ID with conversion and quota requests
- scope quota caching by Firebase UID and installation
- explain the free-plan account/browser rule in pricing, terms and privacy pages
- synchronize the generated backend contract

## Validation
- npm run lint
- npm run test:ci (282 tests passing)
- npm run build:ci
- npm run e2e -- e2e/app.spec.ts (11 tests passing)
- contract, claims, blog and fixture checks passing