### PR TITLE
Set Photocalia as the Google site name

### DIFF
--- a/public/assets/manifest.json
+++ b/public/assets/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "PhotoCalia - AI Calendar Converter",
-  "short_name": "PhotoCalia",
+  "name": "Photocalia - AI Calendar Converter",
+  "short_name": "Photocalia",
   "description": "AI-powered tool to convert photos, screenshots, flyers and PDFs into ICS calendar files. Extracts event dates, times and locations for Google Calendar, Outlook and Apple Calendar.",
   "start_url": "/",
   "display": "standalone",

--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -15,7 +15,7 @@ describe('page route titles', () => {
     }
   });
 
-  it('uses a consistent PhotoCalia separator', () => {
+  it('uses a consistent Photocalia separator', () => {
     for (const route of staticPageRoutes) {
       const occurrences = route.title.split(' | ').length - 1;
       expect(occurrences)
@@ -23,9 +23,9 @@ describe('page route titles', () => {
         .toBe(1);
 
       if (route.path === '') {
-        expect(route.title.startsWith('PhotoCalia | ')).withContext(route.path).toBeTrue();
+        expect(route.title.startsWith('Photocalia | ')).withContext(route.path).toBeTrue();
       } else {
-        expect(route.title.endsWith(' | PhotoCalia'))
+        expect(route.title.endsWith(' | Photocalia'))
           .withContext(route.path ?? '')
           .toBeTrue();
       }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -27,7 +27,7 @@ export class App implements OnInit {
   private readonly seoService = inject(SeoService);
   private readonly languageService = inject(LanguageService);
 
-  protected readonly title = signal('PhotoCalia');
+  protected readonly title = signal('Photocalia');
   private deferredPrompt: BeforeInstallPromptEvent | null = null;
 
   ngOnInit(): void {

--- a/src/app/components/calendar-view/calendar-view.html
+++ b/src/app/components/calendar-view/calendar-view.html
@@ -143,7 +143,7 @@
           width="180"
           height="180"
         />
-        <span class="inline-footer-text">PhotoCalia</span>
+        <span class="inline-footer-text">Photocalia</span>
       </div>
     </div>
   }

--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -13,7 +13,7 @@
             width="180"
             height="180"
           />
-          <span class="logo-text">PhotoCalia</span>
+          <span class="logo-text">Photocalia</span>
         </a>
         <p class="footer-description">{{ 'footer.description' | translate }}</p>
       </div>
@@ -59,7 +59,7 @@
     <div class="footer-bottom">
       <div class="footer-legal">
         <span class="copyright"
-          >© {{ currentYear }} PhotoCalia. {{ 'footer.copyright' | translate }}</span
+          >© {{ currentYear }} Photocalia. {{ 'footer.copyright' | translate }}</span
         >
         <a
           [href]="releaseUrl"

--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -58,9 +58,9 @@
     <!-- Bottom row: copyright, version, social -->
     <div class="footer-bottom">
       <div class="footer-legal">
-        <span class="copyright"
-          >© {{ currentYear }} Photocalia. {{ 'footer.copyright' | translate }}</span
-        >
+        <span class="copyright">
+          © {{ currentYear }} Photocalia. {{ 'footer.copyright' | translate }}
+        </span>
         <a
           [href]="releaseUrl"
           target="_blank"

--- a/src/app/components/header/header.html
+++ b/src/app/components/header/header.html
@@ -3,7 +3,8 @@
     <a [routerLink]="'/' | localizeRoute" class="logo">
       <img
         src="assets/logo.png"
-        alt="Photocalia logo"
+        alt=""
+        aria-hidden="true"
         class="logo-icon-img"
         width="180"
         height="180"

--- a/src/app/components/header/header.html
+++ b/src/app/components/header/header.html
@@ -3,12 +3,12 @@
     <a [routerLink]="'/' | localizeRoute" class="logo">
       <img
         src="assets/logo.png"
-        alt="PhotoCalia logo"
+        alt="Photocalia logo"
         class="logo-icon-img"
         width="180"
         height="180"
       />
-      <span class="logo-text">PhotoCalia</span>
+      <span class="logo-text">Photocalia</span>
     </a>
     <nav class="nav-menu">
       <!-- Language Switcher -->

--- a/src/app/utils/page-title.utils.spec.ts
+++ b/src/app/utils/page-title.utils.spec.ts
@@ -2,11 +2,11 @@ import { homePageTitle, localizedPageTitle, pageTitle } from './page-title.utils
 
 describe('page title utilities', () => {
   it('appends the site name to page titles', () => {
-    expect(pageTitle('Pricing')).toBe('Pricing | PhotoCalia');
+    expect(pageTitle('Pricing')).toBe('Pricing | Photocalia');
   });
 
   it('places the site name first on the home page', () => {
-    expect(homePageTitle('AI calendar converter')).toBe('PhotoCalia | AI calendar converter');
+    expect(homePageTitle('AI calendar converter')).toBe('Photocalia | AI calendar converter');
   });
 
   it('selects the French title for a French route', () => {

--- a/src/app/utils/page-title.utils.ts
+++ b/src/app/utils/page-title.utils.ts
@@ -1,6 +1,6 @@
 import type { ResolveFn } from '@angular/router';
 
-export const SITE_NAME = 'PhotoCalia';
+export const SITE_NAME = 'Photocalia';
 export const PAGE_TITLE_SEPARATOR = ' | ';
 
 export function pageTitle(title: string): string {

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>PhotoCalia | Convert Photos &amp; Screenshots to Calendar Events with AI</title>
+    <title>Photocalia | Convert Photos &amp; Screenshots to Calendar Events with AI</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 
@@ -16,6 +16,7 @@
       content="photo to calendar events, image to calendar converter, picture to calendar app, convert screenshot to Google Calendar, AI calendar from photo, scan flyer to calendar, upload timetable photo, extract events from image, OCR calendar events, calendar converter, PDF to calendar, ICS generator, AI calendar extraction, appointment converter, event converter, Google Calendar import, Outlook calendar, Apple Calendar, iCal converter, free calendar tool, convert image to ICS"
     />
     <meta name="author" content="Idriss" />
+    <meta name="application-name" content="Photocalia" />
     <meta
       name="robots"
       content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
@@ -46,7 +47,7 @@
     <meta property="og:url" content="https://www.photocalia.com/" />
     <meta
       property="og:title"
-      content="PhotoCalia | Convert Photos & Screenshots to Calendar Events with AI"
+      content="Photocalia | Convert Photos & Screenshots to Calendar Events with AI"
     />
     <meta
       property="og:description"
@@ -59,7 +60,7 @@
       property="og:image:alt"
       content="AI Calendar Converter Interface - Convert images and PDFs to calendar events"
     />
-    <meta property="og:site_name" content="PhotoCalia Calendar Converter" />
+    <meta property="og:site_name" content="Photocalia" />
     <meta property="og:locale" content="en_US" />
 
     <!-- Twitter Card Meta Tags -->
@@ -67,7 +68,7 @@
     <meta name="twitter:url" content="https://www.photocalia.com/" />
     <meta
       name="twitter:title"
-      content="PhotoCalia | Convert Photos & Screenshots to Calendar Events with AI"
+      content="Photocalia | Convert Photos & Screenshots to Calendar Events with AI"
     />
     <meta
       name="twitter:description"
@@ -176,9 +177,9 @@
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "name": "PhotoCalia",
-        "alternateName": "PhotoCalia AI Calendar Converter",
-        "url": "https://www.photocalia.com",
+        "name": "Photocalia",
+        "alternateName": "PhotoCalia",
+        "url": "https://www.photocalia.com/",
         "description": "Free AI-powered tool to convert images, screenshots, and PDFs into ICS calendar files compatible with Google Calendar, Outlook, and Apple Calendar.",
         "inLanguage": ["en", "fr"],
         "publisher": {


### PR DESCRIPTION
## What changed

- declare `Photocalia` as the preferred `WebSite` name
- align `og:site_name`, page titles, application metadata, and the PWA manifest
- align the visible brand name in the header and footer
- align the route-title regression test with the preferred casing

## Why

Google Search currently displays `photocalia.com` above the result. These changes provide a consistent, explicit preferred site name across the signals Google documents for site-name selection.

## Validation

- full unit suite passed: 285/285
- production build passed (`Prerendered 50 static routes`)
- lint passed
- all 6 generated JSON-LD blocks parsed successfully
- generated homepage contains `WebSite.name = Photocalia`, the canonical homepage URL, `og:site_name`, and `application-name`