### PR TITLE
Modernize automated screenshot capture

### DIFF
--- a/.github/workflows/update-screenshot.yml
+++ b/.github/workflows/update-screenshot.yml
@@ -68,72 +68,56 @@ jobs:
         if: steps.changes.outputs.should_run == 'true'
         run: npm run build
 
-      - name: Auto-accept cookies for screenshots
+      - name: Install Playwright Chromium
         if: steps.changes.outputs.should_run == 'true'
-        run: |
-          sed -i 's|</head>|<script>localStorage.setItem("photocalia_cookie_consent",JSON.stringify({essential:true,analytics:false,preferences:false,timestamp:Date.now()}))</script></head>|' dist/photocalia/browser/index.html
+        run: npx playwright install --with-deps chromium
 
       - name: Start server in background
         if: steps.changes.outputs.should_run == 'true'
         run: |
-          cd dist/photocalia/browser
-          npx serve -s . -l 4200 &
-          echo "Waiting for server to start..."
-          sleep 15
-          echo "Server should be ready now"
-          # Health check with retry
-          for i in {1..5}; do
-            if curl -s -o /dev/null -w "%{http_code}" http://localhost:4200 | grep -q "200"; then
+          set -euo pipefail
+
+          python3 -m http.server 4200 --bind 127.0.0.1 --directory dist/photocalia/browser \
+            > /tmp/photocalia-screenshot-server.log 2>&1 &
+
+          for i in {1..60}; do
+            if curl --fail --silent http://127.0.0.1:4200 > /dev/null; then
               echo "Server is responding with HTTP 200"
-              break
-            else
-              echo "Attempt $i: Server not ready yet, waiting 2 more seconds..."
-              sleep 2
+              exit 0
             fi
+
+            echo "Attempt $i: server not ready yet"
+            sleep 1
           done
 
-      - name: Check server response before screenshots
-        if: steps.changes.outputs.should_run == 'true'
-        run: |
-          sleep 5
-          curl -i http://localhost:4200
+          cat /tmp/photocalia-screenshot-server.log
+          exit 1
 
-      - name: Install puppeteer-headful
+      - name: Generate screenshot with Playwright
         if: steps.changes.outputs.should_run == 'true'
-        uses: mujo-code/puppeteer-headful@master
-        env:
-          CI: 'true'
+        run: npm run screenshots:capture
 
-      - name: Generate screenshots
-        if: steps.changes.outputs.should_run == 'true'
-        uses: flameddd/screenshots-ci-action@master
-        with:
-          url: http://localhost:4200
-          devices: iPhone 13 Pro Max
-          noCommitHashFileName: true
-          # networkidle0: Wait for all network connections to finish (stricter than networkidle2)
-          # This ensures all external resources (Font Awesome, d3.js, etc.) are loaded
-          # Note: API timeouts added to services (10s) to prevent indefinite waiting
-          waitUntil: networkidle0
-          # Wait for footer to ensure full page render
-          # Components now have timeout handling to render even when APIs fail
-          waitForSelector: 'app-footer'
-          # Extended timeout to allow for Angular bootstrap, API calls (with timeouts), and fallback rendering
-          # Increased from 90s to 120s to account for slower CI environments
-          waitForSelectorTimeout: 120000
-
-      - name: Crop mobile screenshot
+      - name: Install ImageMagick
         if: steps.changes.outputs.should_run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y imagemagick
-          convert screenshots/iPhone_13_Pro_Max.jpeg -crop 1284x2200+0+0 screenshots/iPhone_13_Pro_Max.jpeg
+
+      - name: Crop mobile screenshot
+        if: steps.changes.outputs.should_run == 'true'
+        run: convert screenshots/iPhone_13_Pro_Max.jpeg -crop 1284x2200+0+0 +repage screenshots/iPhone_13_Pro_Max.jpeg
 
       - name: Verify screenshots have content
         if: steps.changes.outputs.should_run == 'true'
         run: |
           echo "Checking mobile screenshot..."
-          identify -verbose screenshots/iPhone_13_Pro_Max.jpeg | grep -E "Geometry|Format"
+          GEOMETRY=$(identify -format '%wx%h' screenshots/iPhone_13_Pro_Max.jpeg)
+          echo "Mobile screenshot geometry: $GEOMETRY"
+
+          if [ "$GEOMETRY" != "1284x2200" ]; then
+            echo "Unexpected screenshot geometry: $GEOMETRY"
+            exit 1
+          fi
 
           # Check file sizes to ensure they're not just empty/background images
           MOBILE_SIZE=$(stat -f%z screenshots/iPhone_13_Pro_Max.jpeg 2>/dev/null || stat -c%s screenshots/iPhone_13_Pro_Max.jpeg)

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ firebase-debug.log
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/screenshots/
 .claude
 
 # Marketing render intermediates

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -58,6 +58,19 @@ dedicated non-production Firebase identity, backend environment and spending lim
 long-lived production token in GitHub Actions. Until that environment exists, the deterministic PR
 smoke protects workflow and ICS behavior but does not claim provider accuracy.
 
+## Screenshot verification
+
+The daily screenshot workflow builds the production site, serves the generated static files and
+captures the mobile viewport with the Playwright version locked by the project. To reproduce the
+capture locally, serve `dist/photocalia/browser` on port 4200, then run:
+
+```bash
+npm run screenshots:capture
+```
+
+The generated `screenshots/` directory is ignored. CI crops the candidate to 1284 x 2200, compares
+it with the published asset and opens or updates a pull request only for a meaningful visual change.
+
 ## High-value manual stories
 
 ### Anonymous visitor

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "blog:generate": "node scripts/generate-blog.mjs",
     "blog:check": "node scripts/generate-blog.mjs --check",
     "claims:check": "node scripts/check-public-claims.mjs",
+    "screenshots:capture": "node scripts/capture-screenshot.mjs",
     "fixtures:generate": "node scripts/generate-golden-fixtures.mjs",
     "fixtures:check": "node scripts/check-golden-dataset.mjs",
     "contracts:update": "node scripts/update-api-contract.mjs && npm run contracts:generate",

--- a/scripts/capture-screenshot.mjs
+++ b/scripts/capture-screenshot.mjs
@@ -31,7 +31,7 @@ try {
   });
 
   const page = await context.newPage();
-  await page.goto(url, { waitUntil: 'networkidle', timeout: 120_000 });
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120_000 });
   await page.addStyleTag({
     content: `
       *, *::before, *::after {

--- a/scripts/capture-screenshot.mjs
+++ b/scripts/capture-screenshot.mjs
@@ -14,6 +14,7 @@ try {
   const context = await browser.newContext({
     ...devices['iPhone 13 Pro Max'],
     locale: 'en-GB',
+    reducedMotion: 'reduce',
     timezoneId: 'Europe/Paris',
   });
 
@@ -31,8 +32,22 @@ try {
 
   const page = await context.newPage();
   await page.goto(url, { waitUntil: 'networkidle', timeout: 120_000 });
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+        scroll-behavior: auto !important;
+      }
+    `,
+  });
   await page.locator('app-footer').waitFor({ state: 'visible', timeout: 120_000 });
-  await page.evaluate(() => document.fonts.ready);
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    document.getAnimations().forEach((animation) => animation.finish());
+  });
   await page.screenshot({
     path: outputPath,
     type: 'jpeg',

--- a/scripts/capture-screenshot.mjs
+++ b/scripts/capture-screenshot.mjs
@@ -1,0 +1,46 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { chromium, devices } from '@playwright/test';
+
+const url = process.env['SCREENSHOT_URL'] ?? 'http://127.0.0.1:4200';
+const outputPath = resolve(process.argv[2] ?? 'screenshots/iPhone_13_Pro_Max.jpeg');
+
+await mkdir(dirname(outputPath), { recursive: true });
+
+const browser = await chromium.launch({ headless: true });
+
+try {
+  const context = await browser.newContext({
+    ...devices['iPhone 13 Pro Max'],
+    locale: 'en-GB',
+    timezoneId: 'Europe/Paris',
+  });
+
+  await context.addInitScript(() => {
+    localStorage.setItem(
+      'photocalia_cookie_consent',
+      JSON.stringify({
+        essential: true,
+        analytics: false,
+        preferences: false,
+        timestamp: Date.now(),
+      }),
+    );
+  });
+
+  const page = await context.newPage();
+  await page.goto(url, { waitUntil: 'networkidle', timeout: 120_000 });
+  await page.locator('app-footer').waitFor({ state: 'visible', timeout: 120_000 });
+  await page.evaluate(() => document.fonts.ready);
+  await page.screenshot({
+    path: outputPath,
+    type: 'jpeg',
+    quality: 90,
+  });
+  await context.close();
+} finally {
+  await browser.close();
+}
+
+console.log(`Screenshot saved to ${outputPath}`);


### PR DESCRIPTION
## Summary
- replace unpinned Puppeteer screenshot actions with the project’s locked Playwright runtime
- use a deterministic local static server and explicit readiness checks
- validate the exact 1284×2200 output and retain meaningful visual-diff filtering
- document local screenshot reproduction and ignore generated artifacts

## Verification
- lint
- 285/285 unit tests
- production build with 50 prerendered routes
- local Playwright capture visually reviewed at the expected mobile width