### PR TITLE
Refresh GitHub Actions and group calendar updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,16 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
       interval: daily
 
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      fullcalendar:
+        patterns:
+          - '@fullcalendar/*'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .node-version
           cache: npm

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,4 +11,4 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@v7

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2026.1
+        uses: JetBrains/qodana-action@v2026.2
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .node-version
           cache: 'npm'

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: 'npm'

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run AI inference
         id: inference
-        uses: actions/ai-inference@v2
+        uses: actions/ai-inference@v3
         with:
           prompt: |
             Summarize the following GitHub issue in one paragraph:

--- a/.github/workflows/update-screenshot.yml
+++ b/.github/workflows/update-screenshot.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.changes.outputs.should_run == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: 'npm'


### PR DESCRIPTION
## Summary
- update setup-node, labeler, AI inference and Qodana actions to the versions already validated independently by Dependabot CI
- group all @fullcalendar packages so future major updates cannot produce incompatible split-version PRs

## Context
The separate FullCalendar 7 PRs failed because v7 core and v6 adapters/plugins cannot be mixed. Grouping the family makes the next migration coherent and reviewable.

## Verification
- all edited YAML passes Prettier validation
- corresponding action-version PRs previously passed frontend CI, audit, Lighthouse, Qodana and Vercel